### PR TITLE
feat(messages): merge attachment handling updates from czy-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.6.6",
+  "version": "1.6.7",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -145,7 +145,7 @@ const OPENCODE_VERSION = "opencode/1.3.15"
 const OPENCODE_LLM_USER_AGENT =
   "opencode/1.3.15 ai-sdk/provider-utils/4.0.21 runtime/bun/1.3.11, opencode/1.3.15"
 
-const COPILOT_VERSION = "0.44.1"
+const COPILOT_VERSION = "0.44.2"
 const EDITOR_PLUGIN_VERSION = `copilot-chat/${COPILOT_VERSION}`
 const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 const CLAUDE_AGENT_USER_AGENT =

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -50,7 +50,6 @@ export interface AnthropicDocumentBlock {
     media_type: "application/pdf"
     data: string
   }
-  context?: string | null
   title?: string | null
 }
 

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -111,6 +111,7 @@ export interface AnthropicTool {
   name: string
   description?: string
   input_schema: Record<string, unknown>
+  defer_loading?: boolean
 }
 
 export interface AnthropicResponse {

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -43,6 +43,17 @@ export interface AnthropicImageBlock {
   }
 }
 
+export interface AnthropicDocumentBlock {
+  type: "document"
+  source: {
+    type: "base64"
+    media_type: "application/pdf"
+    data: string
+  }
+  context?: string | null
+  title?: string | null
+}
+
 export interface AnthropicToolReferenceBlock {
   type: "tool_reference"
   tool_name: string
@@ -51,6 +62,7 @@ export interface AnthropicToolReferenceBlock {
 export type AnthropicToolResultContentBlock =
   | AnthropicTextBlock
   | AnthropicImageBlock
+  | AnthropicDocumentBlock
   | AnthropicToolReferenceBlock
 
 export interface AnthropicToolResultBlock {
@@ -76,6 +88,7 @@ export interface AnthropicThinkingBlock {
 export type AnthropicUserContentBlock =
   | AnthropicTextBlock
   | AnthropicImageBlock
+  | AnthropicDocumentBlock
   | AnthropicToolResultBlock
 
 export type AnthropicAssistantContentBlock =

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -247,6 +247,10 @@ function mapContent(
         })
         break
       }
+      case "document": {
+        contentParts.push(createDocumentTextPart())
+        break
+      }
       case "tool_reference": {
         contentParts.push({
           type: "text",
@@ -258,6 +262,13 @@ function mapContent(
     }
   }
   return contentParts
+}
+
+function createDocumentTextPart(): TextPart {
+  return {
+    type: "text",
+    text: "A PDF document was attached, but this api cannot send PDF inputs directly. Analyze using other tools.",
+  }
 }
 
 function translateAnthropicToolsToOpenAI(

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -167,37 +167,51 @@ const mergeAttachmentsIntoLastToolResult = (
     return content
   }
 
-  let lastToolResultIndex = -1
-  let index = 0
-
-  for (const block of content) {
-    if (block.type === "tool_result" && !hasToolRef(block)) {
-      lastToolResultIndex = index
-    }
-    index += 1
-  }
-
-  if (lastToolResultIndex < 0) {
+  const mergeableToolResultIndices = content.flatMap((block, index) =>
+    block.type === "tool_result" && !hasToolRef(block) ? [index] : [],
+  )
+  if (mergeableToolResultIndices.length === 0) {
     return content
   }
 
-  const mergedContent: Array<AnthropicUserContentBlock> = []
-  index = 0
+  const attachmentsByToolResultIndex = new Map<
+    number,
+    Array<AnthropicAttachmentBlock>
+  >()
 
-  for (const block of content) {
+  if (mergeableToolResultIndices.length === attachments.length) {
+    for (const [
+      index,
+      toolResultIndex,
+    ] of mergeableToolResultIndices.entries()) {
+      attachmentsByToolResultIndex.set(toolResultIndex, [attachments[index]])
+    }
+  } else {
+    const lastToolResultIndex = mergeableToolResultIndices.at(-1)
+    if (lastToolResultIndex === undefined) {
+      return content
+    }
+    attachmentsByToolResultIndex.set(lastToolResultIndex, attachments)
+  }
+
+  const mergedContent: Array<AnthropicUserContentBlock> = []
+
+  for (const [index, block] of content.entries()) {
     if (isAttachmentBlock(block)) {
-      index += 1
       continue
     }
 
-    if (index === lastToolResultIndex && block.type === "tool_result") {
-      mergedContent.push(mergeContentWithAttachments(block, attachments))
-      index += 1
-      continue
+    if (block.type === "tool_result") {
+      const matchedAttachments = attachmentsByToolResultIndex.get(index)
+      if (matchedAttachments) {
+        mergedContent.push(
+          mergeContentWithAttachments(block, matchedAttachments),
+        )
+        continue
+      }
     }
 
     mergedContent.push(block)
-    index += 1
   }
 
   return mergedContent

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -168,7 +168,7 @@ const getMergeableToolResultIndices = (
   toolResults: Array<AnthropicToolResultBlock>,
 ): Array<number> => {
   return toolResults.flatMap((block, index) =>
-    hasToolRef(block) ? [] : [index],
+    block.is_error || hasToolRef(block) ? [] : [index],
   )
 }
 

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -293,7 +293,7 @@ export const sanitizeIdeTools = (payload: AnthropicMessagesPayload): void => {
   }
 
   payload.tools = payload.tools.flatMap((tool) => {
-    if (tool.name === IDE_EXECUTE_CODE_TOOL) {
+    if (tool.name === IDE_EXECUTE_CODE_TOOL && !tool.defer_loading) {
       return []
     }
 

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -13,10 +13,13 @@ import {
 import { getReasoningEffortForModel } from "~/lib/config"
 
 import type {
+  AnthropicDocumentBlock,
+  AnthropicImageBlock,
   AnthropicMessage,
   AnthropicMessagesPayload,
   AnthropicTextBlock,
   AnthropicToolResultBlock,
+  AnthropicUserContentBlock,
 } from "./anthropic-types"
 
 export const TOOL_REFERENCE_TURN_BOUNDARY = "Tool loaded."
@@ -25,6 +28,8 @@ const IDE_EXECUTE_CODE_TOOL = "mcp__ide__executeCode"
 const IDE_GET_DIAGNOSTICS_TOOL = "mcp__ide__getDiagnostics"
 const IDE_GET_DIAGNOSTICS_DESCRIPTION =
   "Get language diagnostics from VS Code. Returns errors, warnings, information, and hints for files in the workspace."
+
+type AnthropicAttachmentBlock = AnthropicImageBlock | AnthropicDocumentBlock
 
 const getCompactCandidateText = (message: AnthropicMessage): string => {
   if (message.role !== "user") {
@@ -131,6 +136,73 @@ const mergeContentWithTexts = (
   return { ...tr, content: [...tr.content, ...textBlocks] }
 }
 
+const mergeContentWithAttachments = (
+  tr: AnthropicToolResultBlock,
+  attachments: Array<AnthropicAttachmentBlock>,
+): AnthropicToolResultBlock => {
+  if (typeof tr.content === "string") {
+    return {
+      ...tr,
+      content: [{ type: "text", text: tr.content }, ...attachments],
+    }
+  }
+
+  return {
+    ...tr,
+    content: [...tr.content, ...attachments],
+  }
+}
+
+const isAttachmentBlock = (
+  block: AnthropicUserContentBlock,
+): block is AnthropicAttachmentBlock => {
+  return block.type === "image" || block.type === "document"
+}
+
+const mergeAttachmentsIntoLastToolResult = (
+  content: Array<AnthropicUserContentBlock>,
+): Array<AnthropicUserContentBlock> => {
+  const attachments = content.filter((block) => isAttachmentBlock(block))
+  if (attachments.length === 0) {
+    return content
+  }
+
+  let lastToolResultIndex = -1
+  let index = 0
+
+  for (const block of content) {
+    if (block.type === "tool_result" && !hasToolRef(block)) {
+      lastToolResultIndex = index
+    }
+    index += 1
+  }
+
+  if (lastToolResultIndex < 0) {
+    return content
+  }
+
+  const mergedContent: Array<AnthropicUserContentBlock> = []
+  index = 0
+
+  for (const block of content) {
+    if (isAttachmentBlock(block)) {
+      index += 1
+      continue
+    }
+
+    if (index === lastToolResultIndex && block.type === "tool_result") {
+      mergedContent.push(mergeContentWithAttachments(block, attachments))
+      index += 1
+      continue
+    }
+
+    mergedContent.push(block)
+    index += 1
+  }
+
+  return mergedContent
+}
+
 const mergeToolResult = (
   toolResults: Array<AnthropicToolResultBlock>,
   textBlocks: Array<AnthropicTextBlock>,
@@ -176,6 +248,8 @@ export const mergeToolResultForClaude = (
     if (options?.skipLastMessage && index === lastMessageIndex) continue
 
     if (msg.role !== "user" || !Array.isArray(msg.content)) continue
+
+    msg.content = mergeAttachmentsIntoLastToolResult(msg.content)
 
     const toolResults: Array<AnthropicToolResultBlock> = []
     const textBlocks: Array<AnthropicTextBlock> = []

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -28,8 +28,13 @@ const IDE_EXECUTE_CODE_TOOL = "mcp__ide__executeCode"
 const IDE_GET_DIAGNOSTICS_TOOL = "mcp__ide__getDiagnostics"
 const IDE_GET_DIAGNOSTICS_DESCRIPTION =
   "Get language diagnostics from VS Code. Returns errors, warnings, information, and hints for files in the workspace."
+const PDF_FILE_READ_PREFIX = "PDF file read:"
 
 type AnthropicAttachmentBlock = AnthropicImageBlock | AnthropicDocumentBlock
+type IndexedAttachment = {
+  attachment: AnthropicAttachmentBlock
+  order: number
+}
 
 const getCompactCandidateText = (message: AnthropicMessage): string => {
   if (message.role !== "user") {
@@ -159,62 +164,234 @@ const isAttachmentBlock = (
   return block.type === "image" || block.type === "document"
 }
 
-const mergeAttachmentsIntoLastToolResult = (
-  content: Array<AnthropicUserContentBlock>,
-): Array<AnthropicUserContentBlock> => {
-  const attachments = content.filter((block) => isAttachmentBlock(block))
-  if (attachments.length === 0) {
-    return content
-  }
-
-  const mergeableToolResultIndices = content.flatMap((block, index) =>
-    block.type === "tool_result" && !hasToolRef(block) ? [index] : [],
+const getMergeableToolResultIndices = (
+  toolResults: Array<AnthropicToolResultBlock>,
+): Array<number> => {
+  return toolResults.flatMap((block, index) =>
+    hasToolRef(block) ? [] : [index],
   )
-  if (mergeableToolResultIndices.length === 0) {
-    return content
+}
+
+const mergeAttachmentsIntoToolResults = (
+  toolResults: Array<AnthropicToolResultBlock>,
+  attachmentsByToolResultIndex: Map<number, Array<IndexedAttachment>>,
+): Array<AnthropicToolResultBlock> => {
+  if (attachmentsByToolResultIndex.size === 0) {
+    return toolResults
   }
 
-  const attachmentsByToolResultIndex = new Map<
-    number,
-    Array<AnthropicAttachmentBlock>
-  >()
+  return toolResults.map((block, index) => {
+    const matchedAttachments = attachmentsByToolResultIndex.get(index)
+    if (!matchedAttachments) {
+      return block
+    }
 
-  if (mergeableToolResultIndices.length === attachments.length) {
-    for (const [
-      index,
-      toolResultIndex,
-    ] of mergeableToolResultIndices.entries()) {
-      attachmentsByToolResultIndex.set(toolResultIndex, [attachments[index]])
-    }
-  } else {
-    const lastToolResultIndex = mergeableToolResultIndices.at(-1)
-    if (lastToolResultIndex === undefined) {
-      return content
-    }
-    attachmentsByToolResultIndex.set(lastToolResultIndex, attachments)
+    const orderedAttachments = [...matchedAttachments]
+      .sort((left, right) => left.order - right.order)
+      .map(({ attachment }) => attachment)
+
+    return mergeContentWithAttachments(block, orderedAttachments)
+  })
+}
+
+const assignAttachmentsToToolResults = (
+  target: Map<number, Array<IndexedAttachment>>,
+  attachments: Array<IndexedAttachment>,
+  options: {
+    toolResultIndices: Array<number>
+    fallbackToolResultIndices?: Array<number>
+  },
+): void => {
+  const { toolResultIndices } = options
+  const fallbackToolResultIndices =
+    options.fallbackToolResultIndices ?? toolResultIndices
+
+  if (attachments.length === 0) {
+    return
   }
 
-  const mergedContent: Array<AnthropicUserContentBlock> = []
+  if (
+    toolResultIndices.length > 0
+    && toolResultIndices.length === attachments.length
+  ) {
+    for (const [index, toolResultIndex] of toolResultIndices.entries()) {
+      const currentAttachments = target.get(toolResultIndex)
+      if (currentAttachments) {
+        currentAttachments.push(attachments[index])
+        continue
+      }
 
-  for (const [index, block] of content.entries()) {
+      target.set(toolResultIndex, [attachments[index]])
+    }
+    return
+  }
+
+  const lastToolResultIndex = fallbackToolResultIndices.at(-1)
+  if (lastToolResultIndex === undefined) {
+    return
+  }
+
+  const currentAttachments = target.get(lastToolResultIndex)
+  if (currentAttachments) {
+    currentAttachments.push(...attachments)
+    return
+  }
+
+  target.set(lastToolResultIndex, [...attachments])
+}
+
+const startsWithPdfFileRead = (
+  toolResult: AnthropicToolResultBlock,
+): boolean => {
+  if (typeof toolResult.content === "string") {
+    return toolResult.content.startsWith(PDF_FILE_READ_PREFIX)
+  }
+
+  if (toolResult.content.some((block) => block.type === "document")) {
+    return false
+  }
+
+  if (toolResult.content.length === 0) {
+    return false
+  }
+
+  const firstBlock = toolResult.content[0]
+  if (firstBlock.type !== "text") {
+    return false
+  }
+
+  return firstBlock.text.startsWith(PDF_FILE_READ_PREFIX)
+}
+
+const collectMergeableUserContent = (
+  content: Array<AnthropicUserContentBlock>,
+): {
+  toolResults: Array<AnthropicToolResultBlock>
+  textBlocks: Array<AnthropicTextBlock>
+  attachments: Array<IndexedAttachment>
+} | null => {
+  const toolResults: Array<AnthropicToolResultBlock> = []
+  const textBlocks: Array<AnthropicTextBlock> = []
+  const attachments: Array<IndexedAttachment> = []
+
+  for (const [order, block] of content.entries()) {
+    if (block.type === "tool_result") {
+      toolResults.push(block)
+      continue
+    }
+    if (block.type === "text") {
+      textBlocks.push(block)
+      continue
+    }
     if (isAttachmentBlock(block)) {
+      attachments.push({ attachment: block, order })
       continue
     }
 
-    if (block.type === "tool_result") {
-      const matchedAttachments = attachmentsByToolResultIndex.get(index)
-      if (matchedAttachments) {
-        mergedContent.push(
-          mergeContentWithAttachments(block, matchedAttachments),
-        )
-        continue
-      }
-    }
-
-    mergedContent.push(block)
+    return null
   }
 
-  return mergedContent
+  return {
+    toolResults,
+    textBlocks,
+    attachments,
+  }
+}
+
+const mergeAttachmentsForToolResults = (
+  toolResults: Array<AnthropicToolResultBlock>,
+  attachments: Array<IndexedAttachment>,
+): Array<AnthropicToolResultBlock> => {
+  if (attachments.length === 0) {
+    return toolResults
+  }
+
+  const documentBlocks = attachments.filter(
+    ({ attachment }) => attachment.type === "document",
+  )
+  const mergeableToolResultIndices = getMergeableToolResultIndices(toolResults)
+  const pdfReadToolResultIndices = mergeableToolResultIndices.filter((index) =>
+    startsWithPdfFileRead(toolResults[index]),
+  )
+
+  const attachmentsByToolResultIndex = new Map<
+    number,
+    Array<IndexedAttachment>
+  >()
+  let remainingAttachments = attachments
+  let countMatchToolResultIndices = mergeableToolResultIndices
+
+  // Match PDF read tool results and documents in order first, then leave any
+  // unmatched documents to the generic fallback path below.
+  if (documentBlocks.length > 0 && pdfReadToolResultIndices.length > 0) {
+    const matchedDocumentCount = Math.min(
+      pdfReadToolResultIndices.length,
+      documentBlocks.length,
+    )
+    const matchedDocuments = documentBlocks.slice(0, matchedDocumentCount)
+    const matchedDocumentOrders = new Set(
+      matchedDocuments.map(({ order }) => order),
+    )
+    const matchedPdfToolResultIndices = pdfReadToolResultIndices.slice(
+      0,
+      matchedDocumentCount,
+    )
+    const matchedPdfToolResultIndexSet = new Set(matchedPdfToolResultIndices)
+
+    assignAttachmentsToToolResults(
+      attachmentsByToolResultIndex,
+      matchedDocuments,
+      {
+        toolResultIndices: matchedPdfToolResultIndices,
+      },
+    )
+    countMatchToolResultIndices = mergeableToolResultIndices.filter(
+      (index) => !matchedPdfToolResultIndexSet.has(index),
+    )
+    remainingAttachments = attachments.filter(
+      ({ attachment, order }) =>
+        attachment.type !== "document" || !matchedDocumentOrders.has(order),
+    )
+  }
+
+  // Everything else keeps the existing count-match / last-tool-result fallback.
+  assignAttachmentsToToolResults(
+    attachmentsByToolResultIndex,
+    remainingAttachments,
+    {
+      toolResultIndices: countMatchToolResultIndices,
+      fallbackToolResultIndices: mergeableToolResultIndices,
+    },
+  )
+
+  return mergeAttachmentsIntoToolResults(
+    toolResults,
+    attachmentsByToolResultIndex,
+  )
+}
+
+const mergeUserMessageContent = (
+  content: Array<AnthropicUserContentBlock>,
+): Array<AnthropicUserContentBlock> | null => {
+  const mergeableContent = collectMergeableUserContent(content)
+  if (!mergeableContent) {
+    return null
+  }
+
+  const { toolResults, textBlocks, attachments } = mergeableContent
+  if (
+    toolResults.length === 0
+    || (textBlocks.length === 0 && attachments.length === 0)
+  ) {
+    return null
+  }
+
+  const mergedToolResults =
+    textBlocks.length === 0 ?
+      toolResults
+    : mergeToolResult(toolResults, textBlocks)
+
+  return mergeAttachmentsForToolResults(mergedToolResults, attachments)
 }
 
 const mergeToolResult = (
@@ -263,26 +440,10 @@ export const mergeToolResultForClaude = (
 
     if (msg.role !== "user" || !Array.isArray(msg.content)) continue
 
-    msg.content = mergeAttachmentsIntoLastToolResult(msg.content)
-
-    const toolResults: Array<AnthropicToolResultBlock> = []
-    const textBlocks: Array<AnthropicTextBlock> = []
-    let valid = true
-
-    for (const block of msg.content) {
-      if (block.type === "tool_result") {
-        toolResults.push(block)
-      } else if (block.type === "text") {
-        textBlocks.push(block)
-      } else {
-        valid = false
-        break
-      }
+    const mergedContent = mergeUserMessageContent(msg.content)
+    if (mergedContent) {
+      msg.content = mergedContent
     }
-
-    if (!valid || toolResults.length === 0 || textBlocks.length === 0) continue
-
-    msg.content = mergeToolResult(toolResults, textBlocks)
   }
 }
 

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -9,6 +9,7 @@ import {
   type ResponsesPayload,
   type ResponseInputCompaction,
   type ResponseInputContent,
+  type ResponseInputFile,
   type ResponseInputImage,
   type ResponseInputItem,
   type ResponseInputMessage,
@@ -33,6 +34,7 @@ import {
 import {
   type AnthropicAssistantContentBlock,
   type AnthropicAssistantMessage,
+  type AnthropicDocumentBlock,
   type AnthropicResponse,
   type AnthropicImageBlock,
   type AnthropicMessage,
@@ -168,8 +170,8 @@ const translateUserMessage = (
     }
 
     const converted = translateUserContentBlock(block)
-    if (converted) {
-      pendingContent.push(converted)
+    if (converted.length > 0) {
+      pendingContent.push(...converted)
     }
   }
 
@@ -247,16 +249,19 @@ const translateAssistantMessage = (
 
 const translateUserContentBlock = (
   block: AnthropicUserContentBlock,
-): ResponseInputContent | undefined => {
+): Array<ResponseInputContent> => {
   switch (block.type) {
     case "text": {
-      return createTextContent(block.text)
+      return [createTextContent(block.text)]
     }
     case "image": {
-      return createImageContent(block)
+      return [createImageContent(block)]
+    }
+    case "document": {
+      return [createFileContent(block)]
     }
     default: {
-      return undefined
+      return []
     }
   }
 }
@@ -347,6 +352,14 @@ const createImageContent = (
   type: "input_image",
   image_url: `data:${block.source.media_type};base64,${block.source.data}`,
   detail: "auto",
+})
+
+const createFileContent = (
+  block: AnthropicDocumentBlock,
+): ResponseInputFile => ({
+  type: "input_file",
+  file_data: `data:${block.source.media_type};base64,${block.source.data}`,
+  filename: block.title ?? "document.pdf",
 })
 
 const createReasoningContent = (
@@ -771,6 +784,10 @@ const convertToolResultContent = (
         }
         case "image": {
           result.push(createImageContent(block))
+          break
+        }
+        case "document": {
+          result.push(createFileContent(block))
           break
         }
         case "tool_reference": {

--- a/src/services/copilot/create-chat-completions.ts
+++ b/src/services/copilot/create-chat-completions.ts
@@ -55,6 +55,8 @@ export const createChatCompletions = async (
 
   prepareForCompact(headers, options.compactType)
 
+  consola.log(`<-- model: ${payload.model}`)
+
   const response = await fetch(`${copilotBaseUrl(state)}/chat/completions`, {
     method: "POST",
     headers,

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -60,7 +60,7 @@ const buildAnthropicBetaHeader = (
     // in vscode copilot extension, advanced-tool-use is enabled by default
     // align header with vscode copilot extension
 
-    // will remove append ADVANCED_TOOL_USE_BETA in next github copilot extension version (>0.44.1)
+    // will remove append ADVANCED_TOOL_USE_BETA in next github copilot extension version (>0.44.2)
     const copilotHeaderSet =
       modelSupportsToolSearch(model) ? [ADVANCED_TOOL_USE_BETA] : []
     const headerSet = new Set([...copilotHeaderSet, ...filteredBeta])
@@ -142,6 +142,8 @@ export const createMessages = async (
   if (anthropicBeta) {
     headers["anthropic-beta"] = anthropicBeta
   }
+
+  consola.log(`<-- model: ${payload.model}`)
 
   const response = await fetch(`${copilotBaseUrl(state)}/v1/messages`, {
     method: "POST",

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -122,6 +122,7 @@ export type ResponseInputItem =
 export type ResponseInputContent =
   | ResponseInputText
   | ResponseInputImage
+  | ResponseInputFile
   | Record<string, unknown>
 
 export interface ResponseInputText {
@@ -134,6 +135,13 @@ export interface ResponseInputImage {
   image_url?: string | null
   file_id?: string | null
   detail: "low" | "high" | "auto"
+}
+
+export interface ResponseInputFile {
+  type: "input_file"
+  file_data?: string | null
+  file_id?: string | null
+  filename?: string | null
 }
 
 export interface ResponsesResult {

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -393,7 +393,9 @@ export const createResponses = async (
   prepareForCompact(headers, compactType)
 
   // service_tier is not supported by github copilot
-  payload.service_tier = null
+  payload.service_tier = undefined
+
+  consola.log(`<-- model: ${payload.model}`)
 
   const response = await fetch(`${copilotBaseUrl(state)}/responses`, {
     method: "POST",

--- a/src/start.ts
+++ b/src/start.ts
@@ -35,6 +35,9 @@ interface RunServerOptions {
 }
 
 export async function runServer(options: RunServerOptions): Promise<void> {
+  // Work around unjs/consola#357 until a release includes PR #359.
+  consola.options.throttle = 0
+
   // Ensure config is merged with defaults at startup
   mergeConfigWithDefaults()
 

--- a/tests/messages-preprocess-pdf-attachments.test.ts
+++ b/tests/messages-preprocess-pdf-attachments.test.ts
@@ -1,0 +1,531 @@
+import { expect, test } from "bun:test"
+
+import type { AnthropicMessagesPayload } from "../src/routes/messages/anthropic-types"
+
+import { mergeToolResultForClaude } from "../src/routes/messages/preprocess"
+
+test("matches pasted PDF documents to PDF file read tool_results", () => {
+  const pdfPath1 = String.raw`/home/user/docs/report2024.pdf`
+  const pdfPath2 = String.raw`/home/user/docs/datasheet.pdf`
+  const pdfReadText1 = `PDF file read: ${pdfPath1} (276.1KB)`
+  const pdfReadText2 = `PDF file read: ${pdfPath2} (943.8KB)`
+
+  const payload: AnthropicMessagesPayload = {
+    model: "claude-opus-4.6",
+    max_tokens: 128,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-pdf-1",
+            content: pdfReadText1,
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "tool-pdf-2",
+            content: pdfReadText2,
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "tool-image-1",
+            content: [
+              {
+                type: "image",
+                source: {
+                  type: "base64",
+                  media_type: "image/jpeg",
+                  data: "image-data",
+                },
+              },
+            ],
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-1",
+            },
+            title: "report2024.pdf",
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-2",
+            },
+            title: "datasheet.pdf",
+          },
+        ],
+      },
+    ],
+  }
+
+  mergeToolResultForClaude(payload)
+
+  expect(payload.messages[0]).toEqual({
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-pdf-1",
+        content: [
+          {
+            type: "text",
+            text: pdfReadText1,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-1",
+            },
+            title: "report2024.pdf",
+          },
+        ],
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-pdf-2",
+        content: [
+          {
+            type: "text",
+            text: pdfReadText2,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-2",
+            },
+            title: "datasheet.pdf",
+          },
+        ],
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-image-1",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/jpeg",
+              data: "image-data",
+            },
+          },
+        ],
+      },
+    ],
+  })
+})
+
+test("preserves image and document order for PDF file read matches", () => {
+  const pdfPath = String.raw`/home/user/docs/report2024.pdf`
+  const pdfReadText = `PDF file read: ${pdfPath} (276.1KB)`
+
+  const payload: AnthropicMessagesPayload = {
+    model: "claude-opus-4.6",
+    max_tokens: 128,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-pdf-1",
+            content: pdfReadText,
+          },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "image-data",
+            },
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data",
+            },
+            title: "report2024.pdf",
+          },
+        ],
+      },
+    ],
+  }
+
+  mergeToolResultForClaude(payload)
+
+  expect(payload.messages[0]).toEqual({
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-pdf-1",
+        content: [
+          {
+            type: "text",
+            text: pdfReadText,
+          },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "image-data",
+            },
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data",
+            },
+            title: "report2024.pdf",
+          },
+        ],
+      },
+    ],
+  })
+})
+
+test("matches PDF documents in order before falling back for leftovers", () => {
+  const pdfPath1 = String.raw`/home/user/docs/report2024.pdf`
+  const pdfPath2 = String.raw`/home/user/docs/datasheet.pdf`
+  const pdfReadText1 = `PDF file read: ${pdfPath1} (276.1KB)`
+  const pdfReadText2 = `PDF file read: ${pdfPath2} (943.8KB)`
+
+  const payload: AnthropicMessagesPayload = {
+    model: "claude-opus-4.6",
+    max_tokens: 128,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-pdf-1",
+            content: pdfReadText1,
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "tool-pdf-2",
+            content: pdfReadText2,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-1",
+            },
+            title: "report2024.pdf",
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-2",
+            },
+            title: "datasheet.pdf",
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-3",
+            },
+            title: "appendix.pdf",
+          },
+        ],
+      },
+    ],
+  }
+
+  mergeToolResultForClaude(payload)
+
+  expect(payload.messages[0]).toEqual({
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-pdf-1",
+        content: [
+          {
+            type: "text",
+            text: pdfReadText1,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-1",
+            },
+            title: "report2024.pdf",
+          },
+        ],
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-pdf-2",
+        content: [
+          {
+            type: "text",
+            text: pdfReadText2,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-2",
+            },
+            title: "datasheet.pdf",
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-3",
+            },
+            title: "appendix.pdf",
+          },
+        ],
+      },
+    ],
+  })
+})
+
+test("excludes matched PDF tool results from leftover count matching", () => {
+  const pdfPath1 = String.raw`/home/user/docs/report2024.pdf`
+  const pdfPath2 = String.raw`/home/user/docs/datasheet.pdf`
+  const pdfReadText1 = `PDF file read: ${pdfPath1} (276.1KB)`
+  const pdfReadText2 = `PDF file read: ${pdfPath2} (943.8KB)`
+
+  const payload: AnthropicMessagesPayload = {
+    model: "claude-opus-4.6",
+    max_tokens: 128,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-general-1",
+            content: "general output",
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "tool-pdf-1",
+            content: pdfReadText1,
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "tool-pdf-2",
+            content: pdfReadText2,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-1",
+            },
+            title: "report2024.pdf",
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-2",
+            },
+            title: "datasheet.pdf",
+          },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "image-data",
+            },
+          },
+        ],
+      },
+    ],
+  }
+
+  mergeToolResultForClaude(payload)
+
+  expect(payload.messages[0]).toEqual({
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-general-1",
+        content: [
+          {
+            type: "text",
+            text: "general output",
+          },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: "image/png",
+              data: "image-data",
+            },
+          },
+        ],
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-pdf-1",
+        content: [
+          {
+            type: "text",
+            text: pdfReadText1,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-1",
+            },
+            title: "report2024.pdf",
+          },
+        ],
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-pdf-2",
+        content: [
+          {
+            type: "text",
+            text: pdfReadText2,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data-2",
+            },
+            title: "datasheet.pdf",
+          },
+        ],
+      },
+    ],
+  })
+})
+
+test("skips PDF read matches when the tool result already contains a document", () => {
+  const pdfPath = String.raw`/home/user/docs/report2024.pdf`
+  const pdfReadText = `PDF file read: ${pdfPath} (276.1KB)`
+
+  const payload: AnthropicMessagesPayload = {
+    model: "claude-opus-4.6",
+    max_tokens: 128,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "tool-pdf-1",
+            content: [
+              {
+                type: "text",
+                text: pdfReadText,
+              },
+              {
+                type: "document",
+                source: {
+                  type: "base64",
+                  media_type: "application/pdf",
+                  data: "existing-pdf-data",
+                },
+                title: "existing.pdf",
+              },
+            ],
+          },
+          {
+            type: "tool_result",
+            tool_use_id: "tool-general-1",
+            content: "general output",
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data",
+            },
+            title: "report2024.pdf",
+          },
+        ],
+      },
+    ],
+  }
+
+  mergeToolResultForClaude(payload)
+
+  expect(payload.messages[0]).toEqual({
+    role: "user",
+    content: [
+      {
+        type: "tool_result",
+        tool_use_id: "tool-pdf-1",
+        content: [
+          {
+            type: "text",
+            text: pdfReadText,
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "existing-pdf-data",
+            },
+            title: "existing.pdf",
+          },
+        ],
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool-general-1",
+        content: [
+          {
+            type: "text",
+            text: "general output",
+          },
+          {
+            type: "document",
+            source: {
+              type: "base64",
+              media_type: "application/pdf",
+              data: "pdf-data",
+            },
+            title: "report2024.pdf",
+          },
+        ],
+      },
+    ],
+  })
+})

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -188,6 +188,92 @@ describe("mergeToolResultForClaude", () => {
 })
 
 describe("mergeToolResultForClaude attachments", () => {
+  test("merges attachments into matching tool_result blocks when counts match", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "first output",
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "tool-2",
+              content: "second output",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data",
+              },
+            },
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "pdf-data",
+              },
+              title: "report.pdf",
+            },
+          ],
+        },
+      ],
+    }
+
+    mergeToolResultForClaude(payload)
+
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool-1",
+          content: [
+            {
+              type: "text",
+              text: "first output",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data",
+              },
+            },
+          ],
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "tool-2",
+          content: [
+            {
+              type: "text",
+              text: "second output",
+            },
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "pdf-data",
+              },
+              title: "report.pdf",
+            },
+          ],
+        },
+      ],
+    })
+  })
+
   test("appends image and document blocks to the last tool_result", () => {
     const payload: AnthropicMessagesPayload = {
       model: "claude-opus-4.6",
@@ -252,6 +338,105 @@ describe("mergeToolResultForClaude attachments", () => {
                 data: "pdf-data",
               },
               title: "report.pdf",
+            },
+          ],
+        },
+      ],
+    })
+  })
+})
+
+describe("mergeToolResultForClaude attachments fallback", () => {
+  test("appends all attachments to the last tool_result when counts differ", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "first output",
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "tool-2",
+              content: "second output",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data-1",
+              },
+            },
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "pdf-data",
+              },
+              title: "report.pdf",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/jpeg",
+                data: "image-data-2",
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    mergeToolResultForClaude(payload)
+
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool-1",
+          content: "first output",
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "tool-2",
+          content: [
+            {
+              type: "text",
+              text: "second output",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data-1",
+              },
+            },
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "pdf-data",
+              },
+              title: "report.pdf",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/jpeg",
+                data: "image-data-2",
+              },
             },
           ],
         },

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -499,7 +499,7 @@ describe("mergeToolResultForClaude attachments fallback", () => {
           content: [
             {
               type: "text",
-              text: "second",
+              text: "second\n\nsecond detail",
             },
             {
               type: "image",
@@ -508,10 +508,6 @@ describe("mergeToolResultForClaude attachments fallback", () => {
                 media_type: "image/png",
                 data: "image-data",
               },
-            },
-            {
-              type: "text",
-              text: "second detail",
             },
           ],
         },

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -187,6 +187,229 @@ describe("mergeToolResultForClaude", () => {
   })
 })
 
+describe("mergeToolResultForClaude attachments", () => {
+  test("appends image and document blocks to the last tool_result", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "binary output",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data",
+              },
+            },
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "pdf-data",
+              },
+              title: "report.pdf",
+            },
+          ],
+        },
+      ],
+    }
+
+    mergeToolResultForClaude(payload)
+
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool-1",
+          content: [
+            {
+              type: "text",
+              text: "binary output",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data",
+              },
+            },
+            {
+              type: "document",
+              source: {
+                type: "base64",
+                media_type: "application/pdf",
+                data: "pdf-data",
+              },
+              title: "report.pdf",
+            },
+          ],
+        },
+      ],
+    })
+  })
+
+  test("keeps text merging and appends attachments to the last tool_result", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "first",
+            },
+            {
+              type: "text",
+              text: "first detail",
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "tool-2",
+              content: "second",
+            },
+            {
+              type: "text",
+              text: "second detail",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data",
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    mergeToolResultForClaude(payload)
+
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool-1",
+          content: "first\n\nfirst detail",
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "tool-2",
+          content: [
+            {
+              type: "text",
+              text: "second",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data",
+              },
+            },
+            {
+              type: "text",
+              text: "second detail",
+            },
+          ],
+        },
+      ],
+    })
+  })
+})
+
+describe("mergeToolResultForClaude attachments with tool_reference", () => {
+  test("falls back to the last tool_result without tool_reference", () => {
+    const payload: AnthropicMessagesPayload = {
+      model: "claude-opus-4.6",
+      max_tokens: 128,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "tool-1",
+              content: "binary output",
+            },
+            {
+              type: "tool_result",
+              tool_use_id: "tool-2",
+              content: [
+                {
+                  type: "tool_reference",
+                  tool_name: "AskUserQuestion",
+                },
+              ],
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data",
+              },
+            },
+          ],
+        },
+      ],
+    }
+
+    mergeToolResultForClaude(payload)
+
+    expect(payload.messages[0]).toEqual({
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "tool-1",
+          content: [
+            {
+              type: "text",
+              text: "binary output",
+            },
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: "image/png",
+                data: "image-data",
+              },
+            },
+          ],
+        },
+        {
+          type: "tool_result",
+          tool_use_id: "tool-2",
+          content: [
+            {
+              type: "tool_reference",
+              tool_name: "AskUserQuestion",
+            },
+          ],
+        },
+      ],
+    })
+  })
+})
+
 describe("prepareMessagesApiPayload", () => {
   test("strips cache_control scope, filters thinking blocks, and enables adaptive thinking", () => {
     const payload: AnthropicMessagesPayload = {

--- a/tests/responses-translation.test.ts
+++ b/tests/responses-translation.test.ts
@@ -138,6 +138,51 @@ describe("translateAnthropicMessagesToResponsesPayload", () => {
       },
     ])
   })
+
+  it("maps document tool results into function_call_output input_file content", () => {
+    const result = translateAnthropicMessagesToResponsesPayload({
+      model: "gpt-4.1",
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_1",
+              content: [
+                {
+                  type: "document",
+                  source: {
+                    type: "base64",
+                    media_type: "application/pdf",
+                    data: "pdf-data",
+                  },
+                  title: "report.pdf",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    })
+
+    const input = result.input as Array<ResponseFunctionCallOutputItem>
+    expect(input).toEqual([
+      {
+        type: "function_call_output",
+        call_id: "call_1",
+        output: [
+          {
+            type: "input_file",
+            filename: "report.pdf",
+            file_data: "data:application/pdf;base64,pdf-data",
+          },
+        ],
+        status: "completed",
+      },
+    ])
+  })
 })
 
 describe("translateResponsesResultToAnthropic", () => {


### PR DESCRIPTION
## Summary
- merge the latest `caozhiyuan/all` content into `czy-all` and publish it to `origin/czy-all`
- add broader attachment handling in the messages pipeline, including PDF/document preprocessing and tool-result merge updates
- refresh related tests for message preprocessing and responses translation coverage

## Validation
- no additional local verification was run in this PR flow; changes were fast-forwarded from `caozhiyuan/all`