### PR TITLE
Sync caozhiyuan all v1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/src/start.ts
+++ b/src/start.ts
@@ -122,6 +122,7 @@ export async function runServer(options: RunServerOptions): Promise<void> {
         CLAUDE_CODE_ATTRIBUTION_HEADER: "0",
         CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION: "false",
         CLAUDE_CODE_DISABLE_TERMINAL_TITLE: "true",
+        CLAUDE_CODE_ENABLE_AWAY_SUMMARY: "0",
         CLAUDE_PLUGIN_ENABLE_QUESTION_RULES: "true",
       },
       "claude",


### PR DESCRIPTION
## Summary
- Syncs `czy-all` with `caozhiyuan/all` through the v1.7.3 version update.
- Carries over `CLAUDE_CODE_ENABLE_AWAY_SUMMARY` environment setup in `src/start.ts`.

## Test plan
- Not run; sync-only branch update with package version/env configuration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)