### PR TITLE
feat: sync caozhiyuan/all v1.8.0 — version bumps & tool-search cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "description": "Turn GitHub Copilot into OpenAI/Anthropic API compatible server. Usable with Claude Code Or Codex Or Opencode!",
   "keywords": [
     "proxy",

--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -141,15 +141,15 @@ export const getOpencodeVersion = () => {
   return OPENCODE_VERSION
 }
 
-const OPENCODE_VERSION = "opencode/1.3.15"
+const OPENCODE_VERSION = "opencode/1.14.29"
 const OPENCODE_LLM_USER_AGENT =
-  "opencode/1.3.15 ai-sdk/provider-utils/4.0.21 runtime/bun/1.3.11, opencode/1.3.15"
+  "opencode/1.14.29 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.13, opencode/1.14.29"
 
-const COPILOT_VERSION = "0.44.2"
+const COPILOT_VERSION = "0.46.0"
 const EDITOR_PLUGIN_VERSION = `copilot-chat/${COPILOT_VERSION}`
 const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 const CLAUDE_AGENT_USER_AGENT =
-  "vscode_claude_code/2.1.98 (external, sdk-ts, agent-sdk/0.2.98)"
+  "vscode_claude_code/2.1.112 (external, sdk-ts, agent-sdk/0.2.112)"
 
 const API_VERSION = "2025-10-01"
 

--- a/src/services/copilot/create-messages.ts
+++ b/src/services/copilot/create-messages.ts
@@ -31,23 +31,10 @@ const allowedAnthropicBetas = new Set([
   ADVANCED_TOOL_USE_BETA,
 ])
 
-const TOOL_SEARCH_SUPPORTED_MODELS = [
-  "claude-sonnet-4.5",
-  "claude-sonnet-4.6",
-  "claude-opus-4.5",
-  "claude-opus-4.6",
-] as const
-
-const modelSupportsToolSearch = (modelId: string): boolean => {
-  return TOOL_SEARCH_SUPPORTED_MODELS.some((prefix) =>
-    modelId.toLowerCase().startsWith(prefix),
-  )
-}
-
 const buildAnthropicBetaHeader = (
   anthropicBetaHeader: string | undefined,
   thinking: AnthropicMessagesPayload["thinking"],
-  model: string,
+  _model: string,
 ): string | undefined => {
   const isAdaptiveThinking = thinking?.type === "adaptive"
 
@@ -60,13 +47,7 @@ const buildAnthropicBetaHeader = (
 
     // in vscode copilot extension, advanced-tool-use is enabled by default
     // align header with vscode copilot extension
-
-    // will remove append ADVANCED_TOOL_USE_BETA in next github copilot extension version (>0.44.2)
-    const copilotHeaderSet =
-      modelSupportsToolSearch(model) ? [ADVANCED_TOOL_USE_BETA] : []
-    const headerSet = new Set([...copilotHeaderSet, ...filteredBeta])
-    const uniqueFilteredBetas = [...headerSet]
-
+    const uniqueFilteredBetas = [...filteredBeta]
     if (uniqueFilteredBetas.length > 0) {
       return uniqueFilteredBetas.join(",")
     }

--- a/src/services/get-vscode-version.ts
+++ b/src/services/get-vscode-version.ts
@@ -1,4 +1,4 @@
-const FALLBACK = "1.116.0"
+const FALLBACK = "1.118.0"
 
 export async function getVSCodeVersion() {
   await Promise.resolve()

--- a/tests/api-config.test.ts
+++ b/tests/api-config.test.ts
@@ -29,7 +29,7 @@ test("prepareMessageProxyHeaders applies message proxy headers by default", () =
   expect(headers["x-interaction-type"]).toBe("messages-proxy")
   expect(headers["openai-intent"]).toBe("messages-proxy")
   expect(headers["user-agent"]).toBe(
-    "vscode_claude_code/2.1.98 (external, sdk-ts, agent-sdk/0.2.98)",
+    "vscode_claude_code/2.1.112 (external, sdk-ts, agent-sdk/0.2.112)",
   )
   expect(headers["x-request-id"]).toBeDefined()
   expect(headers["x-agent-task-id"]).toBe(headers["x-request-id"])


### PR DESCRIPTION
## Summary

从 `caozhiyuan/all` 同步 v1.8.0 变更，主要包含版本升级和 tool-search 逻辑清理。

### 版本升级
- copilot-api: 1.7.3 → 1.8.0
- Copilot extension: 0.44.2 → 0.46.0
- OpenCode: 1.3.15 → 1.14.29
- Claude Code SDK: 2.1.98 → 2.1.112 (agent-sdk 0.2.98 → 0.2.112)
- VSCode fallback: 1.116.0 → 1.118.0

### 逻辑变更
- 移除 `TOOL_SEARCH_SUPPORTED_MODELS` 硬编码列表和 `modelSupportsToolSearch` 函数
- 简化 `buildAnthropicBetaHeader`：不再按模型名条件性添加 `ADVANCED_TOOL_USE_BETA`
- 上游 Copilot extension (>0.44.2) 已默认启用 advanced-tool-use，客户端侧判断不再需要

### 影响文件
- `package.json` — 版本号
- `src/lib/api-config.ts` — 客户端版本常量
- `src/services/copilot/create-messages.ts` — beta header 构建逻辑
- `src/services/get-vscode-version.ts` — VSCode fallback 版本
- `tests/api-config.test.ts` — 对应测试更新