### PR TITLE
Sync caozhiyuan/dev: Responses websocket safety, rate-limit adaptation, server-side compaction (v1.10.25 → v1.10.29)

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.0.0",
+  "version": "1.10.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-api-desktop",
-      "version": "1.0.0",
+      "version": "1.10.27",
       "dependencies": {
         "electron-updater": "^6.3.4"
       },

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.10.27",
+  "version": "1.10.28",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.10.26",
+  "version": "1.10.27",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.10.28",
+  "version": "1.10.29",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.10.25",
+  "version": "1.10.26",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.10.4",
+  "version": "1.10.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.10.4",
+      "version": "1.10.27",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.10.27",
+  "version": "1.10.28",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "ai-gateway",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.10.26",
+  "version": "1.10.27",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "ai-gateway",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.10.25",
+  "version": "1.10.26",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "ai-gateway",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.10.28",
+  "version": "1.10.29",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "ai-gateway",

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -122,10 +122,9 @@ export const handleResponses = async (c: Context) => {
     )
   }
 
-  applyResponsesApiContextManagement(
-    payload,
-    selectedModel?.capabilities.limits.max_prompt_tokens,
-  )
+  // Smaller than the client compaction threshold, use server-side compaction to maintain cache hit rate
+  const maxPromptTokens = selectedModel?.capabilities.limits.max_prompt_tokens
+  applyResponsesApiContextManagement(payload, maxPromptTokens, 0.8)
 
   debugJson(logger, "Translated Responses payload:", payload)
 

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -4,6 +4,9 @@ import { events, type ServerSentEventMessage } from "fetch-event-stream"
 
 import type {
   CreateResponsesReturn,
+  ResponseInputContent,
+  ResponseInputItem,
+  ResponseInputMessage,
   ResponsesPayload,
   ResponseErrorEvent,
   ResponsesResult,
@@ -161,7 +164,7 @@ export function buildCodexResponsesWebSocketPayload(
   payload: ResponsesPayload,
 ): CodexResponsesWebSocketPayload {
   const websocketPayload: CodexResponsesWebSocketPayload = {
-    ...payload,
+    ...normalizeCodexResponsesPayload(payload),
     type: "response.create",
   }
 
@@ -199,23 +202,12 @@ export async function forwardCodexResponses(
     transport?: ResponsesTransport
   } = {},
 ): Promise<CreateResponsesReturn> {
-  const normalizedPayload: ResponsesPayload = {
-    ...payload,
-    store: false,
-    temperature: undefined,
-    top_p: undefined,
-    max_output_tokens: undefined,
-    metadata: undefined,
+  const transport = resolveCodexResponsesTransport(options.transport)
+  if (payload.stream && transport === "websocket") {
+    return forwardCodexResponsesOverWebSocket(payload, requestHeaders, baseUrl)
   }
 
-  const transport = resolveCodexResponsesTransport(options.transport)
-  if (normalizedPayload.stream && transport === "websocket") {
-    return forwardCodexResponsesOverWebSocket(
-      normalizedPayload,
-      requestHeaders,
-      baseUrl,
-    )
-  }
+  const normalizedPayload = normalizeCodexResponsesPayload(payload)
 
   const response = await fetch(resolveCodexResponsesUrl(baseUrl), {
     method: "POST",
@@ -234,6 +226,136 @@ export async function forwardCodexResponses(
   }
 
   return (await response.json()) as ResponsesResult
+}
+
+const normalizeCodexResponsesPayload = (
+  payload: ResponsesPayload,
+): ResponsesPayload => {
+  const normalizedPayload: ResponsesPayload = {
+    ...payload,
+    store: false,
+  }
+
+  delete normalizedPayload.temperature
+  delete normalizedPayload.top_p
+  delete normalizedPayload.max_output_tokens
+  delete normalizedPayload.metadata
+
+  if (
+    (typeof normalizedPayload.instructions === "string"
+      && normalizedPayload.instructions.trim().length > 0)
+    || !Array.isArray(normalizedPayload.input)
+  ) {
+    return normalizedPayload
+  }
+
+  const instructions: Array<string> = []
+  let messageCount = 0
+  const remainingInput = normalizedPayload.input.filter((inputItem) => {
+    const message = getResponseInputMessage(inputItem)
+    if (!message) {
+      return true
+    }
+
+    messageCount += 1
+    if (message.role !== "system" || messageCount > 3) {
+      return true
+    }
+
+    const systemPrompt = getTextContent(message.content)
+    if (systemPrompt === undefined) {
+      return true
+    }
+    if (systemPrompt.trim().length > 0) {
+      instructions.push(systemPrompt)
+    }
+
+    return false
+  })
+
+  if (remainingInput.length === normalizedPayload.input.length) {
+    return normalizedPayload
+  }
+
+  if (instructions.length > 0) {
+    // Codex expects system prompts in instructions instead of input messages.
+    normalizedPayload.instructions = instructions.join("\n\n")
+  }
+
+  if (remainingInput.length > 0) {
+    normalizedPayload.input = remainingInput
+  } else {
+    delete normalizedPayload.input
+  }
+
+  return normalizedPayload
+}
+
+const getResponseInputMessage = (
+  inputItem: ResponseInputItem,
+): ResponseInputMessage | undefined => {
+  if (typeof inputItem !== "object" || inputItem === null) {
+    return undefined
+  }
+
+  const { role, type } = inputItem as {
+    role?: unknown
+    type?: unknown
+  }
+  if (typeof role !== "string" || (type !== undefined && type !== "message")) {
+    return undefined
+  }
+
+  return inputItem as ResponseInputMessage
+}
+
+const getTextContent = (
+  content: ResponseInputMessage["content"],
+): string | undefined => {
+  if (typeof content === "string") {
+    return content
+  }
+
+  if (content === undefined) {
+    return ""
+  }
+
+  if (!Array.isArray(content)) {
+    return undefined
+  }
+
+  const textBlocks: Array<string> = []
+  for (const contentBlock of content) {
+    const text = getTextBlock(contentBlock)
+    if (text === undefined) {
+      return undefined
+    }
+
+    if (text.length > 0) {
+      textBlocks.push(text)
+    }
+  }
+
+  return textBlocks.join("\n\n")
+}
+
+const getTextBlock = (
+  contentBlock: ResponseInputContent,
+): string | undefined => {
+  if (typeof contentBlock !== "object" || contentBlock === null) {
+    return undefined
+  }
+
+  const { text, type } = contentBlock as {
+    text?: unknown
+    type?: unknown
+  }
+
+  if (type !== undefined && type !== "input_text" && type !== "output_text") {
+    return undefined
+  }
+
+  return typeof text === "string" ? text : undefined
 }
 
 const buildCodexResponsesWebSocketPoolKey = (

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -135,7 +135,7 @@ export function buildCodexResponsesHeaders(
     headers.set("originator", "opencode")
     const sessionId = requestContext.getStore()?.sessionAffinity
     if (sessionId) {
-      headers.set("session_id", sessionId)
+      headers.set("session-id", sessionId)
     }
   }
   return headers
@@ -372,9 +372,9 @@ const buildCodexResponsesWebSocketPoolKey = (
   const headerFingerprint = createHash("sha256")
     .update(
       JSON.stringify(
-        Object.entries(headers).sort(([left], [right]) =>
-          left.localeCompare(right),
-        ),
+        Object.entries(headers)
+          .filter(([headerName]) => !headerName.toLowerCase().includes("trace"))
+          .sort(([left], [right]) => left.localeCompare(right)),
       ),
     )
     .digest("hex")

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -357,6 +357,10 @@ export interface ResponseErrorEvent {
   param: string | null
   sequence_number: number
   type: "error"
+  error?: {
+    code: string | null
+    message: string
+  }
 }
 
 export interface ResponseFunctionCallArgumentsDeltaEvent {
@@ -655,9 +659,19 @@ const createResponsesWebSocketStreamChunk = (
       copilot_quota_snapshots?: Record<string, CopilotQuotaSnapshot>
       id?: unknown
       type?: unknown
+      error?: {
+        code: string | null
+        message: string
+      }
+      code?: string | null
+      message?: string
     }
     if (parsed.type === "response.completed") {
       logCopilotQuotaSnapshots(parsed.copilot_quota_snapshots)
+    }
+    if (parsed.type === "error" && parsed.error) {
+      parsed.code = parsed.error.code
+      parsed.message = parsed.error.message
     }
     return {
       data: JSON.stringify(parsed),

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -436,6 +436,12 @@ export type ResponsesStream = ReturnType<typeof events>
 export type CreateResponsesReturn = ResponsesResult | ResponsesStream
 export type ResponsesTransport = "http" | "websocket"
 
+type ResponsesStreamChunk = {
+  data?: string
+  event?: string
+  id?: string | number
+}
+
 interface ResponsesRequestOptions {
   vision: boolean
   initiator: "agent" | "user"
@@ -581,14 +587,26 @@ export const getResponsesWebSocketInitiator = (
 const createPooledResponsesWebSocketStream = (
   request: ResponsesWebSocketRequest,
 ): ResponsesStream =>
-  createPooledWebSocketStream(request, {
-    createChunk: createResponsesWebSocketStreamChunk,
-    isTerminalChunk: isTerminalResponsesStreamChunk,
-    openErrorMessage: "Failed to create responses websocket",
-    streamErrorMessage: "Responses websocket stream error",
-    terminalChunkMissingMessage:
-      "Responses websocket ended without a terminal response",
-  }) as ResponsesStream
+  createResponsesSafeStream(
+    createPooledWebSocketStream(request, {
+      createChunk: createResponsesWebSocketStreamChunk,
+      isTerminalChunk: isTerminalResponsesStreamChunk,
+      openErrorMessage: "Failed to create responses websocket",
+      streamErrorMessage: "Responses websocket stream error",
+      terminalChunkMissingMessage:
+        "Responses websocket ended without a terminal response",
+    }),
+  )
+
+const createResponsesSafeStream = async function* (
+  source: AsyncIterable<ResponsesStreamChunk>,
+): AsyncGenerator<ResponsesStreamChunk, void, unknown> {
+  try {
+    yield* source
+  } catch (error) {
+    yield createResponsesErrorServerSentEventChunk(getErrorMessage(error))
+  }
+}
 
 export const buildResponsesWebSocketPayload = (
   payload: ResponsesPayload,
@@ -667,4 +685,29 @@ const isTerminalResponsesStreamChunk = (chunk: { data?: string }): boolean => {
   } catch {
     return false
   }
+}
+
+const createResponsesErrorServerSentEventChunk = (
+  message: string,
+): ResponsesStreamChunk => {
+  const errorEvent: ResponseErrorEvent = {
+    code: null,
+    message,
+    param: null,
+    sequence_number: 0,
+    type: "error",
+  }
+
+  return {
+    data: JSON.stringify(errorEvent),
+    event: errorEvent.type,
+  }
+}
+
+const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  return String(error)
 }

--- a/tests/codex-create-responses.test.ts
+++ b/tests/codex-create-responses.test.ts
@@ -62,6 +62,48 @@ describe("codex api helpers", () => {
     expect("stream" in payload).toBe(false)
   })
 
+  test("moves system input messages into instructions when they are empty", () => {
+    const payload = buildCodexResponsesWebSocketPayload({
+      input: [
+        { role: "system", content: "follow the repo style" },
+        { role: "user", content: "hello" },
+      ],
+      instructions: "",
+      model: "gpt-5.4",
+      stream: true,
+    })
+
+    expect(payload).toEqual({
+      input: [{ role: "user", content: "hello" }],
+      instructions: "follow the repo style",
+      model: "gpt-5.4",
+      store: false,
+      type: "response.create",
+    })
+  })
+
+  test("keeps system messages after the first three messages in input", () => {
+    const payload = buildCodexResponsesWebSocketPayload({
+      input: [
+        { role: "user", content: "first" },
+        { role: "assistant", content: "second" },
+        { role: "user", content: "third" },
+        { role: "system", content: "late system prompt" },
+      ],
+      instructions: null,
+      model: "gpt-5.4",
+      stream: true,
+    })
+
+    expect(payload.instructions).toBeNull()
+    expect(payload.input).toEqual([
+      { role: "user", content: "first" },
+      { role: "assistant", content: "second" },
+      { role: "user", content: "third" },
+      { role: "system", content: "late system prompt" },
+    ])
+  })
+
   test("overrides request account headers with loaded codex auth context", () => {
     state.codexAccessToken = "codex-token"
     state.codexAccountId = "codex-account"

--- a/tests/codex-websocket.test.ts
+++ b/tests/codex-websocket.test.ts
@@ -161,6 +161,19 @@ const createResponsesResult = (
   usage: null,
 })
 
+const mockFetchJsonResponse = (body: unknown): void => {
+  fetchMock.mockImplementation(() =>
+    Promise.resolve(
+      new Response(JSON.stringify(body), {
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+        },
+        status: 200,
+      }),
+    ),
+  )
+}
+
 beforeEach(() => {
   MockWebSocket.autoComplete = true
   MockWebSocket.instances = []
@@ -182,19 +195,7 @@ afterEach(() => {
 })
 
 test("forwardCodexResponses falls back to HTTP for non-streaming responses", async () => {
-  fetchMock.mockImplementation(() => {
-    return Promise.resolve(
-      new Response(
-        JSON.stringify(createResponsesResult("gpt-5.4", "resp-http")),
-        {
-          headers: {
-            "content-type": "application/json; charset=utf-8",
-          },
-          status: 200,
-        },
-      ),
-    )
-  })
+  mockFetchJsonResponse(createResponsesResult("gpt-5.4", "resp-http"))
 
   const response = await forwardCodexResponses(
     {
@@ -248,6 +249,39 @@ test("forwardCodexResponses falls back to HTTP for non-streaming responses", asy
     model: "gpt-5.4",
     status: "completed",
   })
+})
+
+test("forwardCodexResponses moves system input messages into instructions for HTTP requests", async () => {
+  mockFetchJsonResponse(createResponsesResult("gpt-5.4", "resp-http-system"))
+
+  await forwardCodexResponses(
+    {
+      input: [
+        { role: "system", content: "follow the repo style" },
+        { role: "user", content: "hello" },
+      ],
+      instructions: null,
+      model: "gpt-5.4",
+    },
+    new Headers({
+      "content-type": "application/json",
+    }),
+  )
+
+  expect(fetchMock).toHaveBeenCalledTimes(1)
+
+  const requestInit = fetchMock.mock.calls[0]?.[1]
+  if (typeof requestInit?.body !== "string") {
+    throw new Error("Expected codex HTTP request body to be a string")
+  }
+
+  const payload = JSON.parse(requestInit.body) as {
+    input?: Array<{ content?: string; role?: string }>
+    instructions?: string | null
+  }
+
+  expect(payload.instructions).toBe("follow the repo style")
+  expect(payload.input).toEqual([{ role: "user", content: "hello" }])
 })
 
 test("forwardCodexResponses returns HTTP event streams when stream=true", async () => {

--- a/tests/create-responses-websocket-pool.test.ts
+++ b/tests/create-responses-websocket-pool.test.ts
@@ -228,17 +228,26 @@ test("Responses websocket open failure includes the underlying reason", async ()
     error: new Error("tls handshake failed"),
   }
 
-  let thrown: unknown = null
+  const response = await createResponses(
+    {
+      input: "hello",
+      model: "gpt-test",
+      stream: true,
+    },
+    {
+      initiator: "user",
+      requestId: "request-1",
+      transport: "websocket",
+      vision: false,
+    },
+  )
 
-  try {
-    await collectResponsesStream("request-1")
-  } catch (error) {
-    thrown = error
-  }
+  const chunks = await collectStreamChunks(response as AsyncIterable<unknown>)
 
-  expect(thrown).toBeInstanceOf(Error)
-  expect((thrown as Error).message).toBe(
-    "Failed to create responses websocket: tls handshake failed",
+  expect(chunks).toHaveLength(1)
+  expect(chunks[0]?.event).toBe("error")
+  expect(chunks[0]?.data).toContain(
+    '"message":"Failed to create responses websocket: tls handshake failed"',
   )
 })
 
@@ -490,24 +499,64 @@ test("Responses websocket sequential request reuses the pooled connection after 
 test("Responses websocket stream failure includes the underlying reason", async () => {
   MockWebSocket.autoComplete = false
 
-  const streamPromise = collectResponsesStream("request-1")
+  const response = await createResponses(
+    {
+      input: "hello",
+      model: "gpt-test",
+      stream: true,
+    },
+    {
+      initiator: "user",
+      requestId: "request-1",
+      transport: "websocket",
+      vision: false,
+    },
+  )
+  const chunksPromise = collectStreamChunks(response as AsyncIterable<unknown>)
+
   await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
 
   MockWebSocket.instances[0]?.emitError({
     error: new Error("socket hang up"),
   })
 
-  let thrown: unknown = null
+  const chunks = await chunksPromise
 
-  try {
-    await streamPromise
-  } catch (error) {
-    thrown = error
-  }
+  expect(chunks).toHaveLength(1)
+  expect(chunks[0]?.event).toBe("error")
+  expect(chunks[0]?.data).toContain(
+    '"message":"Responses websocket stream error: socket hang up"',
+  )
+})
 
-  expect(thrown).toBeInstanceOf(Error)
-  expect((thrown as Error).message).toBe(
-    "Responses websocket stream error: socket hang up",
+test("Responses websocket emits an error event when the websocket closes without a terminal response", async () => {
+  MockWebSocket.autoComplete = false
+
+  const response = await createResponses(
+    {
+      input: "hello",
+      model: "gpt-test",
+      stream: true,
+    },
+    {
+      initiator: "user",
+      requestId: "request-1",
+      transport: "websocket",
+      vision: false,
+    },
+  )
+  const chunksPromise = collectStreamChunks(response as AsyncIterable<unknown>)
+
+  await waitFor(() => MockWebSocket.instances[0]?.sent.length === 1)
+
+  MockWebSocket.instances[0]?.close()
+
+  const chunks = await chunksPromise
+
+  expect(chunks).toHaveLength(1)
+  expect(chunks[0]?.event).toBe("error")
+  expect(chunks[0]?.data).toContain(
+    '"message":"Responses websocket ended without a terminal response"',
   )
 })
 
@@ -550,6 +599,23 @@ const collectResponsesStream = async (requestId: string): Promise<void> => {
   for await (const _chunk of response as AsyncIterable<unknown>) {
     // consume stream
   }
+}
+
+const collectStreamChunks = async (
+  stream: AsyncIterable<unknown>,
+): Promise<Array<{ data?: string; event?: string; id?: string | number }>> => {
+  const chunks: Array<{ data?: string; event?: string; id?: string | number }> =
+    []
+
+  for await (const chunk of stream as AsyncIterable<{
+    data?: string
+    event?: string
+    id?: string | number
+  }>) {
+    chunks.push(chunk)
+  }
+
+  return chunks
 }
 
 const waitFor = async (predicate: () => boolean): Promise<void> => {


### PR DESCRIPTION
## Summary

Sync upstream `caozhiyuan/dev` into this repo via `czy-all` (`v1.10.25` → `v1.10.29`).

Main upstream changes:
- `4114f18` feat: enhance payload normalization and testing for system input messages in Codex responses
- `9af7d99` feat: standardize session ID header naming and improve header fingerprinting logic
- `83ce487` feat: implement safe streaming for responses websocket and handle error events
- `e9016ef` feat: copilot rate limit error adaptation
- `371d531` feat: enhance Responses API context management with server-side compaction
- version bumps through `v1.10.29`

Touched 10 files (+390 / -70), centered on:
- `src/services/codex/create-responses.ts`
- `src/services/copilot/create-responses.ts`
- Responses websocket / pool tests
- package versions and lockfiles

## Test plan

- [ ] Check GitHub mergeability
- [ ] If conflicts exist, resolve locally through `dev <- czy-all` per best-of-both-worlds hunk approval workflow
- [ ] Run project verification after conflict resolution: `bun run lint:all --fix`, `bun run build`, `bun test`, `bun run typecheck`
