### PR TITLE
sync: upstream caozhiyuan/dev (v1.12.0) - billing header normalization, model ID split, codex header cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,7 @@ Here is an example `.claude/settings.json` file:
 - Turning off CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION and CLAUDE_CODE_ENABLE_AWAY_SUMMARY can prevent quota from being consumed unnecessarily.
 - Claude Code WebSearch is supported for pure search requests. For Copilot, keep the global `messageApiWebSearchModel` set to a Responses-capable GPT model or a `provider/model` alias. For provider routes, use a native Anthropic provider or an `openai-responses` provider. Add `WebSearch` to `permissions.deny` only if you want to forbid this traffic.
 - If using a non-Claude model, do not enable ENABLE_TOOL_SEARCH. If using the Claude model, can enable ENABLE_TOOL_SEARCH. The current Claude Code uses the client tool search mode. In this mode, loading defer tools requires an additional request each time.
+- `CLAUDE_CODE_AUTO_COMPACT_WINDOW`: Set the context capacity in tokens used for auto-compaction calculations. Defaults to the model's context window: 200K for standard models or 1M for extended context models. Use a lower value like `500000` on a 1M model (e.g., `claude-opus-4-6[1m]`) to treat the window as 500K for compaction purposes. The value is capped at the model's actual context window. `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` is applied as a percentage of this value. Setting this variable decouples the compaction threshold from the status line's `used_percentage`, which always uses the model's full context window.
 
 You can find more options here: [Claude Code settings](https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ English | [简体中文](./README.zh-CN.md)
 > [!IMPORTANT]
 > **Before using, please be aware of the following:**
 >
-> 1. **Claude Code configuration:** When using with Claude Code, please configure the model ID as `claude-opus-4-6` or `claude-opus-4.6` (without the `[1m]` suffix, exceeding GitHub Copilot's context window limit too much may lead to being banned). Example claude `settings.json` see [Manual Configuration with `settings.json`](#manual-configuration-with-settingsjson). 
+> 1. **Claude Code configuration:** When using with Claude Code, please configure the model ID as `claude-opus-4-6` or `claude-opus-4.6`. Example claude `settings.json` see [Manual Configuration with `settings.json`](#manual-configuration-with-settingsjson). 
 >
 > 2. **Recommend for Opencode:** For opencode, prefer the opencode OAuth app. It matches opencode's built-in GitHub Copilot provider and avoids Terms of Service risk:
 >    ```sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,7 +7,7 @@
 > [!IMPORTANT]
 > **使用前请先注意以下几点：**
 >
-> 1. **Claude Code 配置：** 与 Claude Code 搭配使用时，请将模型 ID 配置为 `claude-opus-4-6` 或 `claude-opus-4.6`（不要带 `[1m]` 后缀，超出 GitHub Copilot 上下文窗口限制太多可能导致账号被封）。示例 claude `settings.json` 见 [通过 `settings.json` 手动配置](#manual-configuration-with-settingsjson)。
+> 1. **Claude Code 配置：** 与 Claude Code 搭配使用时，请将模型 ID 配置为 `claude-opus-4-6` 或 `claude-opus-4.6`。示例 claude `settings.json` 见 [通过 `settings.json` 手动配置](#manual-configuration-with-settingsjson)。
 >
 > 2. **推荐给 opencode 用户：** 对 opencode 而言，优先使用 opencode OAuth app。它与 opencode 内置的 GitHub Copilot provider 行为一致，且没有 Terms of Service 风险：
 >    ```sh

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -428,6 +428,7 @@ npx @jeffreycao/copilot-api@latest start --claude-code
 - 关闭 `CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION` 和 `CLAUDE_CODE_ENABLE_AWAY_SUMMARY` 可以避免不必要地消耗额度。
 - Claude Code WebSearch 已支持纯搜索请求。Copilot 路径请保持全局 `messageApiWebSearchModel` 指向 Responses-capable GPT 模型或 `provider/model` 别名；provider 路由请使用原生 Anthropic provider 或 `openai-responses` provider。只有在你明确想禁止这类流量时，才需要把 `WebSearch` 加到 `permissions.deny`。
 - 如果使用的不是 Claude 模型，请不要启用 `ENABLE_TOOL_SEARCH`。如果使用的是 Claude 模型，则可以启用 `ENABLE_TOOL_SEARCH`。当前 Claude Code 使用的是客户端 tool search 模式，在该模式下每次加载 defer tools 都需要额外请求一次。
+- `CLAUDE_CODE_AUTO_COMPACT_WINDOW`：设置用于自动压缩计算的上下文容量（以 token 为单位）。默认使用模型自身的上下文窗口：标准模型为 200K，扩展上下文模型为 1M。使用 1M 上下文模型（如 `claude-opus-4-6[1m]`）时，可设置一个较低的值（如 `500000`）将窗口视为 500K 用于压缩计算。该值受限于模型的实际上下文窗口上限。`CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` 会基于此值的百分比生效。设置此变量可将压缩阈值与状态栏的 `used_percentage` 解耦（后者始终使用模型的完整上下文窗口）。
 
 更多选项见：[Claude Code settings](https://docs.anthropic.com/en/docs/claude-code/settings#environment-variables)
 

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.11.6",
+  "version": "1.11.8",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.11.8",
+  "version": "1.12.0",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
+    "github-copilot",
+    "codex",
     "ai-gateway",
-    "github-copilot"
+    "multi-provider"
   ],
   "homepage": "https://github.com/caozhiyuan/copilot-api",
   "bugs": "https://github.com/caozhiyuan/copilot-api/issues",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.11.5",
+  "version": "1.11.6",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "ai-gateway",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "ai-gateway",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.11.6",
+  "version": "1.11.8",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "ai-gateway",

--- a/src/lib/api-config.ts
+++ b/src/lib/api-config.ts
@@ -145,7 +145,7 @@ const OPENCODE_VERSION = "opencode/1.14.29"
 const OPENCODE_LLM_USER_AGENT =
   "opencode/1.14.29 ai-sdk/provider-utils/4.0.23 runtime/bun/1.3.13, opencode/1.14.29"
 
-const COPILOT_VERSION = "0.50.1"
+const COPILOT_VERSION = "0.52.0"
 const EDITOR_PLUGIN_VERSION = `copilot-chat/${COPILOT_VERSION}`
 const USER_AGENT = `GitHubCopilotChat/${COPILOT_VERSION}`
 const CLAUDE_AGENT_USER_AGENT =
@@ -153,7 +153,7 @@ const CLAUDE_AGENT_USER_AGENT =
 const COPILOT_WEBSOCKET_VERSION = COPILOT_VERSION
 const EDITOR_WEBSOCKET_PLUGIN_VERSION = `copilot-chat/${COPILOT_WEBSOCKET_VERSION}`
 
-const API_VERSION = "2026-01-09"
+const API_VERSION = "2026-06-01"
 const WEBSOCKET_API_VERSION = API_VERSION
 
 export const copilotBaseUrl = (state: State) => {

--- a/src/lib/models.ts
+++ b/src/lib/models.ts
@@ -11,7 +11,7 @@ import { state } from "~/lib/state"
 export const toClientModelId = (modelId: string): string => {
   const normalized = normalizeSdkModelId(modelId)
   if (!normalized) return modelId
-  const versionHyphenated = normalized.version.replace(/\./g, "-")
+  const versionHyphenated = normalized.version.replaceAll(".", "-")
   return `claude-${normalized.family}-${versionHyphenated}`
 }
 

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -33,7 +33,6 @@ import {
   getCompactType,
   getLastMessageContentCacheControl,
   mergeToolResultForClaude,
-  normalizeClaudeCodeBillingHeaderInSystem,
   normalizeSystemMessages,
   sanitizeIdeTools,
   stripToolReferenceTurnBoundary,
@@ -79,7 +78,6 @@ export async function handleCompletion(c: Context) {
 
   debugJson(logger, "Anthropic request payload:", anthropicPayload)
 
-  normalizeClaudeCodeBillingHeaderInSystem(anthropicPayload)
   normalizeSystemMessages(anthropicPayload)
 
   await checkRateLimit(state)

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -33,6 +33,7 @@ import {
   getCompactType,
   getLastMessageContentCacheControl,
   mergeToolResultForClaude,
+  normalizeClaudeCodeBillingHeaderInSystem,
   normalizeSystemMessages,
   sanitizeIdeTools,
   stripToolReferenceTurnBoundary,
@@ -78,6 +79,7 @@ export async function handleCompletion(c: Context) {
 
   debugJson(logger, "Anthropic request payload:", anthropicPayload)
 
+  normalizeClaudeCodeBillingHeaderInSystem(anthropicPayload)
   normalizeSystemMessages(anthropicPayload)
 
   await checkRateLimit(state)

--- a/src/routes/messages/handler.ts
+++ b/src/routes/messages/handler.ts
@@ -107,11 +107,11 @@ export async function handleCompletion(c: Context) {
     logger.debug("Compact request type:", compactType)
   }
 
-  const lastMessageCacheControl = getLastMessageContentCacheControl(
-    anthropicPayload.messages.at(-1),
-  )
-
   if (!state.tokenBasedBilling) {
+    const lastMessageCacheControl = getLastMessageContentCacheControl(
+      anthropicPayload.messages.at(-1),
+    )
+
     stripToolReferenceTurnBoundary(anthropicPayload)
 
     // Merge tool_result and text blocks into tool_result to avoid consuming premium requests
@@ -122,9 +122,9 @@ export async function handleCompletion(c: Context) {
     mergeToolResultForClaude(anthropicPayload, {
       skipLastMessage: compactType === COMPACT_REQUEST,
     })
-  }
 
-  applyLastMessageCacheControl(anthropicPayload, lastMessageCacheControl)
+    applyLastMessageCacheControl(anthropicPayload, lastMessageCacheControl)
+  }
 
   const requestId = generateRequestIdFromPayload(anthropicPayload, sessionId)
   logger.debug("Generated request ID:", requestId)

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -196,6 +196,8 @@ export const normalizeClaudeCodeBillingHeaderInSystem = (
 export const normalizeSystemMessages = (
   payload: AnthropicMessagesPayload,
 ): void => {
+  normalizeClaudeCodeBillingHeaderInSystem(payload)
+
   if (!payload.messages.some((msg) => msg.role === "system")) {
     return
   }

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -38,6 +38,8 @@ const IDE_GET_DIAGNOSTICS_TOOL = "mcp__ide__getDiagnostics"
 const IDE_GET_DIAGNOSTICS_DESCRIPTION =
   "Get language diagnostics from VS Code. Returns errors, warnings, information, and hints for files in the workspace."
 const PDF_FILE_READ_PREFIX = "PDF file read:"
+const CLAUDE_CODE_BILLING_HEADER_PREFIX = "x-anthropic-billing-header:"
+const CLAUDE_CODE_CCH_SEGMENT_PATTERN = /(^|;\s*)cch=[^;]+;/u
 
 type AnthropicAttachmentBlock = AnthropicImageBlock | AnthropicDocumentBlock
 type AnthropicMessageContentBlock =
@@ -157,6 +159,38 @@ const prependSystemContentToUserMessage = (
       [createTextBlock(message.content)]
     : message.content),
   ]
+}
+
+const normalizeClaudeCodeBillingHeader = (text: string): string => {
+  if (!text.startsWith(CLAUDE_CODE_BILLING_HEADER_PREFIX)) {
+    return text
+  }
+
+  return text.replace(CLAUDE_CODE_CCH_SEGMENT_PATTERN, "$1cch=<stable>;")
+}
+
+export const normalizeClaudeCodeBillingHeaderInSystem = (
+  payload: AnthropicMessagesPayload,
+): void => {
+  const system = payload.system
+  if (!system) {
+    return
+  }
+
+  if (typeof system === "string") {
+    payload.system = normalizeClaudeCodeBillingHeader(system)
+    return
+  }
+
+  if (system.length === 0) {
+    return
+  }
+
+  payload.system = system.map((block, index) =>
+    index === 0 ?
+      { ...block, text: normalizeClaudeCodeBillingHeader(block.text) }
+    : block,
+  )
 }
 
 export const normalizeSystemMessages = (

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -43,7 +43,7 @@ import type {
   AnthropicWebSearchContentBlock,
   AnthropicWebSearchResultItem,
 } from "../anthropic-types"
-import { getCompactType } from "../preprocess"
+import { getCompactType, normalizeSystemMessages } from "../preprocess"
 import { translateAnthropicMessagesToResponsesPayload } from "../responses-translation"
 import { parseSubagentMarkerFromFirstUser } from "../subagent-marker"
 import {
@@ -609,6 +609,8 @@ export const tryHandleWebSearch = async (
   },
 ): Promise<Response | null> => {
   if (!hasWebSearchServerTool(payload)) return null
+
+  normalizeSystemMessages(payload)
 
   const route = resolveWebSearchRoute(payload, {
     webSearchModel: getMessageApiWebSearchModel(),

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -17,9 +17,11 @@ modelRoutes.get("/", async (c) => {
       const capabilities = model.capabilities
       const contextWindow = capabilities?.limits?.max_context_window_tokens ?? 0
       const clientId = toClientModelId(model.id)
+      const is1m = contextWindow >= 1_000_000
       return {
+        claude_model_id: is1m ? `${clientId}[1m]` : clientId,
         ...model,
-        id: contextWindow > 1_000_000 ? `${clientId}[1m]` : clientId,
+        id: clientId,
         object: "model",
         type: "model",
         created: 0,

--- a/src/routes/provider/responses/handler.ts
+++ b/src/routes/provider/responses/handler.ts
@@ -163,7 +163,7 @@ const streamProviderResponses = async (
   const firstChunk = firstResult.value
   if (firstChunk.data && firstChunk.data !== "[DONE]") {
     const event = parseProviderResponsesStreamEvent(firstChunk.data, {
-      normalizeCodex: options.normalizeCodex,
+      normalizeCodex: false,
       provider: options.provider,
     })
     if (event?.type === "error") {

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -41,7 +41,9 @@ interface CodexResponsesHeaderOptions {
 }
 
 const STRIPPED_CODEX_REQUEST_HEADERS = new Set([
+  "accept-encoding",
   "authorization",
+  "cdn-loop",
   "connection",
   "content-length",
   "host",
@@ -51,8 +53,11 @@ const STRIPPED_CODEX_REQUEST_HEADERS = new Set([
   "te",
   "trailer",
   "transfer-encoding",
+  "true-client-ip",
   "upgrade",
   "x-api-key",
+  "x-forwarded-for",
+  "x-forwarded-proto",
 ])
 
 const STRIPPED_CODEX_WEBSOCKET_HEADERS = new Set(["accept", "content-type"])
@@ -106,6 +111,9 @@ export function buildCodexResponsesHeaders(
       continue
     }
     if (headerNameLower.includes("trace")) {
+      continue
+    }
+    if (headerNameLower.startsWith("cf-")) {
       continue
     }
     headers.set(headerName, headerValue)

--- a/src/services/get-vscode-version.ts
+++ b/src/services/get-vscode-version.ts
@@ -1,4 +1,4 @@
-const FALLBACK = "1.122.1"
+const FALLBACK = "1.124.2"
 
 export async function getVSCodeVersion() {
   await Promise.resolve()

--- a/src/services/responses-websocket.ts
+++ b/src/services/responses-websocket.ts
@@ -1,3 +1,4 @@
+import consola from "consola"
 import { WebSocket } from "undici"
 
 import { getProxyEnvDispatcher } from "~/lib/proxy"
@@ -110,6 +111,7 @@ const getPooledWebSocketRequestTarget = <TPayload, TChunk>(
 
   const existing = websocketPool.get(request.poolKey)
   if (existing && !existing.closed) {
+    consola.debug("websocket from pool")
     clearPooledWebSocketIdleTimer(existing)
     return {
       entry: existing,

--- a/tests/create-responses.test.ts
+++ b/tests/create-responses.test.ts
@@ -216,7 +216,7 @@ describe("createResponses", () => {
       "Copilot-Integration-Id": "vscode-chat",
       "Copilot-Vision-Request": "true",
       "Editor-Device-Id": "device-1",
-      "Editor-Plugin-Version": "copilot-chat/0.50.1",
+      "Editor-Plugin-Version": "copilot-chat/0.52.0",
       "Editor-Version": "vscode/1.120.0",
       "OpenAI-Intent": "conversation-agent",
       "VScode-SessionId": "session-1",

--- a/tests/create-responses.test.ts
+++ b/tests/create-responses.test.ts
@@ -222,7 +222,7 @@ describe("createResponses", () => {
       "VScode-SessionId": "session-1",
       "VScode-MachineId": "machine-1",
       "X-Agent-Task-Id": "request-1",
-      "X-GitHub-Api-Version": "2026-01-09",
+      "X-GitHub-Api-Version": "2026-06-01",
       "X-Interaction-Id": "interaction-1",
       "X-Interaction-Type": "conversation-agent",
       "X-Request-Id": "request-1",

--- a/tests/messages-handler.test.ts
+++ b/tests/messages-handler.test.ts
@@ -13,6 +13,9 @@ const actualConfigModule = await import("../src/lib/config")
 const actualModelsModule = await import("../src/lib/models")
 const actualRateLimitModule = await import("../src/lib/rate-limit")
 const actualUtilsModule = await import("../src/lib/utils")
+const { responsesUtilsDependencies } = await import(
+  "../src/routes/responses/utils"
+)
 
 const state = {
   ...actualStateModule.state,
@@ -22,6 +25,7 @@ const state = {
 }
 
 let messagesApiEnabled = true
+let responsesApiWebSocketEnabled = true
 let modelMappings: Record<string, string> = {}
 type SelectedModel = {
   id: string
@@ -74,6 +78,7 @@ await mock.module("~/lib/config", () => ({
   ...actualConfigModule,
   getSmallModel: () => "small-model",
   isMessagesApiEnabled: () => messagesApiEnabled,
+  isResponsesApiWebSocketEnabled: () => responsesApiWebSocketEnabled,
   resolveMappedModel: (model: string) => modelMappings[model] ?? model,
 }))
 await mock.module("~/lib/models", () => ({
@@ -88,6 +93,7 @@ const { handleCompletion, messagesFlowHandlers } = await import(
 )
 
 const defaultMessagesFlowHandlers = { ...messagesFlowHandlers }
+const defaultResponsesUtilsDependencies = { ...responsesUtilsDependencies }
 
 const createApp = () => {
   const app = new Hono()
@@ -108,8 +114,12 @@ beforeEach(() => {
   state.manualApprove = false
   state.verbose = false
   messagesApiEnabled = true
+  responsesApiWebSocketEnabled = true
   modelMappings = {}
   selectedModel = undefined
+
+  responsesUtilsDependencies.isResponsesApiWebSocketEnabled = () =>
+    responsesApiWebSocketEnabled
 
   messagesFlowHandlers.handleWithMessagesApi = handleWithMessagesApi
   messagesFlowHandlers.handleWithResponsesApi = handleWithResponsesApi
@@ -129,6 +139,7 @@ afterEach(() => {
     defaultMessagesFlowHandlers.handleWithResponsesApi
   messagesFlowHandlers.handleWithChatCompletions =
     defaultMessagesFlowHandlers.handleWithChatCompletions
+  Object.assign(responsesUtilsDependencies, defaultResponsesUtilsDependencies)
 })
 
 describe("messages handler orchestration", () => {
@@ -441,7 +452,51 @@ describe("messages handler orchestration", () => {
     expect(forwardedPayload.model).toBe("messages-model")
   })
 
-  test("delegates to the Responses API flow when the model supports /responses", async () => {
+  test("stabilizes Claude Code billing header before forwarding to the Messages API flow", async () => {
+    selectedModel = {
+      id: "messages-model",
+      supported_endpoints: ["/v1/messages"],
+    }
+
+    const app = createApp()
+    const response = await app.request("/", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(
+        createPayload({
+          system: [
+            {
+              type: "text",
+              text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=6fb32;",
+            },
+            {
+              type: "text",
+              text: "You are Claude Code, Anthropic's official CLI for Claude.",
+            },
+          ],
+        }),
+      ),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toBe("messages")
+
+    const [, forwardedPayload] = handleWithMessagesApi.mock.calls[0]
+    expect(forwardedPayload.system).toEqual([
+      {
+        type: "text",
+        text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=<stable>;",
+      },
+      {
+        type: "text",
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+      },
+    ])
+  })
+
+  test("stabilizes Claude Code billing header before forwarding to the Responses API flow", async () => {
     selectedModel = {
       id: "responses-model",
       supported_endpoints: ["/responses"],
@@ -453,7 +508,20 @@ describe("messages handler orchestration", () => {
       headers: {
         "content-type": "application/json",
       },
-      body: JSON.stringify(createPayload()),
+      body: JSON.stringify(
+        createPayload({
+          system: [
+            {
+              type: "text",
+              text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=6fb32;",
+            },
+            {
+              type: "text",
+              text: "You are Claude Code, Anthropic's official CLI for Claude.",
+            },
+          ],
+        }),
+      ),
     })
 
     expect(response.status).toBe(200)
@@ -461,9 +529,22 @@ describe("messages handler orchestration", () => {
     expect(handleWithMessagesApi).not.toHaveBeenCalled()
     expect(handleWithResponsesApi).toHaveBeenCalledTimes(1)
     expect(handleWithChatCompletions).not.toHaveBeenCalled()
+
+    const [, forwardedPayload] = handleWithResponsesApi.mock.calls[0]
+    expect(forwardedPayload.system).toEqual([
+      {
+        type: "text",
+        text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=<stable>;",
+      },
+      {
+        type: "text",
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+      },
+    ])
   })
 
   test("delegates to the Responses API flow when the model supports ws:/responses", async () => {
+    responsesApiWebSocketEnabled = true
     selectedModel = {
       id: "responses-ws-model",
       supported_endpoints: ["ws:/responses"],
@@ -516,7 +597,7 @@ describe("messages handler orchestration", () => {
     expect(handleWithChatCompletions).toHaveBeenCalledTimes(1)
   })
 
-  test("falls back to the Chat Completions flow when no endpoint matches", async () => {
+  test("stabilizes Claude Code billing header before falling back to the Chat Completions flow", async () => {
     selectedModel = {
       id: "chat-model",
       supported_endpoints: [],
@@ -528,7 +609,20 @@ describe("messages handler orchestration", () => {
       headers: {
         "content-type": "application/json",
       },
-      body: JSON.stringify(createPayload()),
+      body: JSON.stringify(
+        createPayload({
+          system: [
+            {
+              type: "text",
+              text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=6fb32;",
+            },
+            {
+              type: "text",
+              text: "You are Claude Code, Anthropic's official CLI for Claude.",
+            },
+          ],
+        }),
+      ),
     })
 
     expect(response.status).toBe(200)
@@ -536,6 +630,18 @@ describe("messages handler orchestration", () => {
     expect(handleWithMessagesApi).not.toHaveBeenCalled()
     expect(handleWithResponsesApi).not.toHaveBeenCalled()
     expect(handleWithChatCompletions).toHaveBeenCalledTimes(1)
+
+    const [, forwardedPayload] = handleWithChatCompletions.mock.calls[0]
+    expect(forwardedPayload.system).toEqual([
+      {
+        type: "text",
+        text: "x-anthropic-billing-header: cc_version=2.1.158.c0c; cc_entrypoint=cli; cch=<stable>;",
+      },
+      {
+        type: "text",
+        text: "You are Claude Code, Anthropic's official CLI for Claude.",
+      },
+    ])
   })
 
   test("applies warmup model override and passes request metadata to the selected flow", async () => {

--- a/tests/messages-preprocess.test.ts
+++ b/tests/messages-preprocess.test.ts
@@ -1,6 +1,21 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
 
 import type { AnthropicMessagesPayload } from "../src/routes/messages/anthropic-types"
+
+const actualConfigModule = await import("../src/lib/config")
+
+let mockedReasoningEffort:
+  | "none"
+  | "minimal"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh" = "xhigh"
+
+await mock.module("~/lib/config", () => ({
+  ...actualConfigModule,
+  getReasoningEffortForModel: () => mockedReasoningEffort,
+}))
 
 import {
   applyLastMessageCacheControl,
@@ -11,6 +26,14 @@ import {
   sanitizeIdeTools,
   stripToolReferenceTurnBoundary,
 } from "../src/routes/messages/preprocess"
+
+beforeEach(() => {
+  mockedReasoningEffort = "xhigh"
+})
+
+afterEach(() => {
+  mockedReasoningEffort = "xhigh"
+})
 
 describe("normalizeSystemMessages", () => {
   test("merges system string content into the previous message", () => {

--- a/tests/responses-translation.test.ts
+++ b/tests/responses-translation.test.ts
@@ -190,6 +190,30 @@ describe("translateAnthropicMessagesToResponsesPayload", () => {
     expect(result.prompt_cache_key).toBe("opencode-session:agent:agent-123")
   })
 
+  it("keeps unrelated system prompt text unchanged", () => {
+    const payload = {
+      model: "gpt-5.4",
+      max_tokens: 1024,
+      system: [
+        {
+          type: "text",
+          text: "ordinary system prompt",
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "hello gpt54" }],
+        },
+      ],
+    } as unknown as AnthropicMessagesPayload
+
+    const result = translateAnthropicMessagesToResponsesPayload(payload)
+
+    expect(result.instructions).toContain("ordinary system prompt")
+    expect(result.instructions).not.toContain("cch=<stable>;")
+  })
+
   it("ignores blank subagent agent_id", () => {
     const result = translateAnthropicMessagesToResponsesPayload(
       {


### PR DESCRIPTION
## Upstream sync: caozhiyuan/dev -> czy-all -> dev

13 commits fast-forwarded from caozhiyuan/dev (dc3d4aa..8a4fc12).

### Feature changes

1. Claude Code billing header normalization - cch value stabilized before forwarding to Copilot backend
2. Model ID structure split - /v1/models returns standard id, adds claude_model_id with [1m] for >=1M context
3. Codex request header cleanup - strips cf-*, cdn-loop, true-client-ip, x-forwarded-for, x-forwarded-proto
4. Cache control scoped to non-token-billing branch only
5. Version bumps - Copilot 0.50.1->0.52.0, API 2026-01-09->2026-06-01, project 1.11.4->1.12.0