### PR TITLE
Sync upstream web search and messages compatibility updates

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.3",
+      "version": "1.13.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.2",
+      "version": "1.13.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.3",
+  "version": "1.13.4",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -23,11 +23,18 @@ export interface AnthropicMessagesPayload {
   service_tier?: "auto" | "standard_only"
   output_config?: {
     effort?: "low" | "medium" | "high" | "xhigh" | "max"
+    format?: BetaJSONOutputFormat | null
   }
   metadata?: {
     user_id?: string
   }
   temperature?: number
+}
+
+export interface BetaJSONOutputFormat {
+  schema: { [key: string]: unknown }
+
+  type: "json_schema"
 }
 
 export interface AnthropicCacheControl {

--- a/src/routes/messages/anthropic-types.ts
+++ b/src/routes/messages/anthropic-types.ts
@@ -178,13 +178,29 @@ export type AnthropicWebSearchContentBlock =
   | AnthropicServerToolUseBlock
   | AnthropicWebSearchToolResultBlock
 
-export interface AnthropicResponse {
+export interface AnthropicUsage {
+  input_tokens: number
+  output_tokens: number
+  cache_creation_input_tokens?: number
+  cache_read_input_tokens?: number
+  service_tier?: "standard" | "priority" | "batch"
+  server_tool_use?: {
+    web_search_requests?: number
+  }
+}
+
+export type AnthropicResponseContentBlock =
+  | AnthropicAssistantContentBlock
+  | AnthropicWebSearchContentBlock
+
+export interface AnthropicResponse<
+  TContentBlock extends
+    AnthropicResponseContentBlock = AnthropicResponseContentBlock,
+> {
   id: string
   type: "message"
   role: "assistant"
-  content: Array<
-    AnthropicAssistantContentBlock | AnthropicWebSearchContentBlock
-  >
+  content: Array<TContentBlock>
   model: string
   stop_reason:
     | "end_turn"
@@ -195,18 +211,8 @@ export interface AnthropicResponse {
     | "refusal"
     | null
   stop_sequence: string | null
-  usage: {
-    input_tokens: number
-    output_tokens: number
-    cache_creation_input_tokens?: number
-    cache_read_input_tokens?: number
-    service_tier?: "standard" | "priority" | "batch"
-  }
+  usage: AnthropicUsage
 }
-
-export type AnthropicResponseContentBlock =
-  | AnthropicAssistantContentBlock
-  | AnthropicWebSearchContentBlock
 
 // Anthropic Stream Event Types
 export interface AnthropicMessageStartEvent {
@@ -230,6 +236,8 @@ export interface AnthropicContentBlockStartEvent {
         input: Record<string, unknown>
       })
     | { type: "thinking"; thinking: string }
+    | AnthropicServerToolUseBlock
+    | AnthropicWebSearchToolResultBlock
 }
 
 export interface AnthropicContentBlockDeltaEvent {

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -900,4 +900,19 @@ export const prepareMessagesApiPayload = (
       effort: effort,
     }
   }
+
+  // Drop reasoning effort for models that can't use it. A model that supports
+  // adaptive_thinking accepts an effort (handled in the branch above), so this
+  // only targets non-adaptive_thinking models (e.g. claude-haiku-4.5) that also
+  // declare no supported efforts. For those, an effort arriving on the request
+  // would otherwise be forwarded and rejected with `invalid_reasoning_effort`.
+  if (
+    !selectedModel?.capabilities.supports.adaptive_thinking
+    && payload.output_config?.effort
+  ) {
+    const supported = selectedModel?.capabilities.supports.reasoning_effort
+    if (!supported || supported.length === 0) {
+      delete payload.output_config
+    }
+  }
 }

--- a/src/routes/messages/preprocess.ts
+++ b/src/routes/messages/preprocess.ts
@@ -912,7 +912,10 @@ export const prepareMessagesApiPayload = (
   ) {
     const supported = selectedModel?.capabilities.supports.reasoning_effort
     if (!supported || supported.length === 0) {
-      delete payload.output_config
+      delete payload.output_config.effort
+      if (Object.keys(payload.output_config).length === 0) {
+        delete payload.output_config
+      }
     }
   }
 }

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -38,8 +38,10 @@ import {
 } from "~/services/copilot/create-responses"
 
 import type {
+  AnthropicContentBlockStartEvent,
   AnthropicMessagesPayload,
   AnthropicResponse,
+  AnthropicStreamEventData,
   AnthropicTextBlock,
   AnthropicTool,
   AnthropicWebSearchContentBlock,
@@ -160,11 +162,6 @@ export const extractWebSearchConfig = (
   }
 }
 
-export interface ReconstructedWebSearchResponse
-  extends Omit<AnthropicResponse, "content"> {
-  content: Array<AnthropicTextBlock | AnthropicWebSearchContentBlock>
-}
-
 const buildWebSearchResultBlock = (
   toolUseId: string,
   extract: WebSearchExtract,
@@ -241,10 +238,14 @@ export const reconstructWebSearchResponse = (
   options: { requestId: string },
 ): {
   extract: WebSearchExtract
-  response: ReconstructedWebSearchResponse
+  response: AnthropicResponse<
+    AnthropicTextBlock | AnthropicWebSearchContentBlock
+  >
 } => {
   const extract = extractWebSearchResult(result)
-  const response: ReconstructedWebSearchResponse = {
+  const response: AnthropicResponse<
+    AnthropicTextBlock | AnthropicWebSearchContentBlock
+  > = {
     id: result.id || getUUID(options.requestId),
     type: "message",
     role: "assistant",
@@ -258,7 +259,7 @@ export const reconstructWebSearchResponse = (
       server_tool_use: {
         web_search_requests: Math.max(extract.queries.length, 1),
       },
-    } as AnthropicResponse["usage"],
+    },
   }
 
   return { extract, response }
@@ -293,7 +294,7 @@ export const collectWebSearchResponsesStreamResult = async ({
   const state = createWebSearchResponsesStreamCollection()
 
   for await (const chunk of upstreamResponse) {
-    debugJson(logger, "Received web search responses stream chunk:", chunk.data)
+    debugJson(logger, "Received web search responses stream chunk:", chunk)
     if (chunk.event === "ping") {
       continue
     }
@@ -733,21 +734,21 @@ export const handleWebSearchViaResponses = async (
 
 // --- Synthetic SSE replay -------------------------------------------------
 
-interface SyntheticEvent {
-  type: string
-  [key: string]: unknown
-}
-
 const blockToStreamEvents = (
   block: AnthropicTextBlock | AnthropicWebSearchContentBlock,
   index: number,
-): Array<SyntheticEvent> => {
-  const start = (contentBlock: unknown): SyntheticEvent => ({
+): Array<AnthropicStreamEventData> => {
+  const start = (
+    contentBlock: AnthropicContentBlockStartEvent["content_block"],
+  ): AnthropicContentBlockStartEvent => ({
     type: "content_block_start",
     index,
     content_block: contentBlock,
   })
-  const stop: SyntheticEvent = { type: "content_block_stop", index }
+  const stop: AnthropicStreamEventData = {
+    type: "content_block_stop",
+    index,
+  }
 
   switch (block.type) {
     case "text": {
@@ -791,9 +792,11 @@ const blockToStreamEvents = (
 }
 
 export const buildSyntheticStreamEvents = (
-  response: ReconstructedWebSearchResponse,
-): Array<SyntheticEvent> => {
-  const events: Array<SyntheticEvent> = []
+  response: AnthropicResponse<
+    AnthropicTextBlock | AnthropicWebSearchContentBlock
+  >,
+): Array<AnthropicStreamEventData> => {
+  const events: Array<AnthropicStreamEventData> = []
 
   events.push({
     type: "message_start",

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -47,9 +47,8 @@ import type {
   AnthropicWebSearchContentBlock,
   AnthropicWebSearchResultItem,
 } from "../anthropic-types"
-import { getCompactType, normalizeSystemMessages } from "../preprocess"
+import { normalizeSystemMessages } from "../preprocess"
 import { translateAnthropicMessagesToResponsesPayload } from "../responses-translation"
-import { parseSubagentMarkerFromFirstUser } from "../subagent-marker"
 import {
   getResponsesRequestOptions,
   getResponsesTransportForModel,
@@ -229,6 +228,10 @@ export const prepareWebSearchResponsesPayload = (
   )
   responsesPayload.tools = [buildResponsesWebSearchTool(config)]
   responsesPayload.tool_choice = undefined
+  responsesPayload.reasoning = {
+    effort: "medium",
+    summary: "auto",
+  }
   return responsesPayload
 }
 
@@ -265,19 +268,8 @@ export const reconstructWebSearchResponse = (
   return { extract, response }
 }
 
-interface CollectedOutputTextPart {
-  annotations: Array<unknown>
-  contentIndex: number
-  itemId?: string
-  outputIndex: number
-  text: string
-}
-
 interface WebSearchResponsesStreamCollection {
-  createdResponse?: ResponsesResult
   outputItemsByIndex: Map<number, ResponsesResult["output"][number]>
-  terminalResponse?: ResponsesResult
-  textPartsByKey: Map<string, CollectedOutputTextPart>
 }
 
 export const collectWebSearchResponsesStreamResult = async ({
@@ -308,16 +300,15 @@ export const collectWebSearchResponsesStreamResult = async ({
       continue
     }
 
-    collectResponsesStreamEvent(parsed, state)
-
     if (parsed.type === "error") {
       throw new Error(
         getStreamErrorMessage(parsed) ?? `${errorMessagePrefix} failed`,
       )
     }
 
-    if (isResponsesTerminalEvent(parsed)) {
-      return buildWebSearchResponsesStreamResult(state)
+    const result = collectResponsesStreamEvent(parsed, state)
+    if (result) {
+      return result
     }
   }
 
@@ -343,232 +334,43 @@ const isWebSearchResponsesStream = (
   )
 }
 
-const isResponsesTerminalEvent = (
-  event: ResponseStreamEvent,
-): event is ResponseStreamEvent & {
-  response: ResponsesResult
-  type: "response.completed" | "response.failed" | "response.incomplete"
-} =>
-  event.type === "response.completed"
-  || event.type === "response.failed"
-  || event.type === "response.incomplete"
-
 const createWebSearchResponsesStreamCollection =
   (): WebSearchResponsesStreamCollection => ({
     outputItemsByIndex: new Map(),
-    textPartsByKey: new Map(),
   })
 
 const collectResponsesStreamEvent = (
   event: ResponseStreamEvent,
   state: WebSearchResponsesStreamCollection,
-): void => {
+): ResponsesResult | undefined => {
   switch (event.type) {
-    case "response.created":
-      state.createdResponse = event.response
-      break
     case "response.completed":
     case "response.failed":
-    case "response.incomplete":
-      if (isResponsesTerminalEvent(event)) {
-        event.response.copilot_usage ??= event.copilot_usage as CopilotUsage
-        state.terminalResponse = event.response
+    case "response.incomplete": {
+      event.response.copilot_usage ??= event.copilot_usage as CopilotUsage
+      const response = event.response
+      if (!response) {
+        throw new Error("Web search responses stream ended without a response")
       }
-      break
-    case "response.output_item.added":
+      const output = [...state.outputItemsByIndex.entries()]
+        .sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
+        .map(([, item]) => item)
+      return {
+        ...response,
+        output: output.length > 0 ? output : response.output,
+      }
+    }
     case "response.output_item.done":
       state.outputItemsByIndex.set(event.output_index, event.item)
       break
-    case "response.output_text.delta": {
-      const part = getOrCreateOutputTextPart(event, state)
-      if (part && event.delta) {
-        part.text += event.delta
-      }
-      break
-    }
-    case "response.output_text.done": {
-      const part = getOrCreateOutputTextPart(event, state)
-      if (part) {
-        part.text = event.text
-      }
-      break
-    }
-    case "response.output_text.annotation.added": {
-      const part = getOrCreateOutputTextPart(event, state)
-      const annotation = event.annotation
-      if (part && annotation !== undefined) {
-        part.annotations.push(annotation)
-      }
-      break
-    }
-    case "response.content_part.done":
-      collectDoneContentPart(event, state)
-      break
-    case "response.in_progress":
-    case "response.content_part.added":
-    case "response.web_search_call.in_progress":
-    case "response.web_search_call.searching":
-    case "response.web_search_call.completed":
-    case "response.reasoning_summary_part.added":
-    case "response.reasoning_summary_part.done":
-    case "response.reasoning_summary_text.delta":
-    case "response.reasoning_summary_text.done":
-      // Progress/reasoning events are intentionally ignored here; output_item,
-      // output_text/content_part.done, annotations, and terminal response are
-      // enough to rebuild the web_search result.
-      break
   }
 }
-
-const buildWebSearchResponsesStreamResult = (
-  state: WebSearchResponsesStreamCollection,
-): ResponsesResult => {
-  const response = state.terminalResponse ?? state.createdResponse
-  if (!response) {
-    throw new Error("Web search responses stream ended without a response")
-  }
-
-  const output = buildCollectedWebSearchOutput(state)
-  return {
-    ...response,
-    output: output.length > 0 ? output : response.output,
-  }
-}
-
-const buildCollectedWebSearchOutput = (
-  state: WebSearchResponsesStreamCollection,
-): ResponsesResult["output"] =>
-  [...state.outputItemsByIndex.entries()]
-    .sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
-    .map(([outputIndex, item]) =>
-      mergeOutputItemWithCollectedText(outputIndex, item, state),
-    )
-
-const mergeOutputItemWithCollectedText = (
-  outputIndex: number,
-  item: ResponsesResult["output"][number],
-  state: WebSearchResponsesStreamCollection,
-): ResponsesResult["output"][number] => {
-  if (item.type !== "message") {
-    return item
-  }
-
-  const collectedParts = getCollectedTextParts(outputIndex, state)
-  if (collectedParts.length === 0) {
-    return item
-  }
-
-  const content = item.content ? [...item.content] : []
-  for (const part of collectedParts) {
-    const existingPart = getRecord(content[part.contentIndex])
-    content[part.contentIndex] = {
-      ...existingPart,
-      type: "output_text",
-      text: part.text,
-      annotations: mergeAnnotations(
-        existingPart?.annotations,
-        part.annotations,
-      ),
-    }
-  }
-
-  return {
-    ...item,
-    content,
-  }
-}
-
-const collectDoneContentPart = (
-  event: Extract<ResponseStreamEvent, { type: "response.content_part.done" }>,
-  state: WebSearchResponsesStreamCollection,
-): void => {
-  const partRecord = getRecord(event.part)
-  if (partRecord?.type !== "output_text") {
-    return
-  }
-
-  const part = getOrCreateOutputTextPart(event, state)
-  if (!part) {
-    return
-  }
-
-  const text = getString(partRecord.text)
-  if (text !== undefined) {
-    part.text = text
-  }
-
-  const annotations = getArray(partRecord.annotations)
-  if (annotations.length > 0) {
-    part.annotations.push(...annotations)
-  }
-}
-
-const getOrCreateOutputTextPart = (
-  event: Extract<
-    ResponseStreamEvent,
-    { content_index: number; output_index: number }
-  >,
-  state: WebSearchResponsesStreamCollection,
-): CollectedOutputTextPart | undefined => {
-  const outputIndex = event.output_index
-  const contentIndex = event.content_index
-  if (outputIndex === undefined || contentIndex === undefined) {
-    return undefined
-  }
-
-  const key = `${outputIndex}:${contentIndex}`
-  let part = state.textPartsByKey.get(key)
-  if (!part) {
-    part = {
-      annotations: [],
-      contentIndex,
-      itemId: getString(event.item_id),
-      outputIndex,
-      text: "",
-    }
-    state.textPartsByKey.set(key, part)
-  }
-
-  return part
-}
-
-const getCollectedTextParts = (
-  outputIndex: number,
-  state: WebSearchResponsesStreamCollection,
-): Array<CollectedOutputTextPart> =>
-  [...state.textPartsByKey.values()]
-    .filter((part) => part.outputIndex === outputIndex)
-    .sort(
-      (left, right) =>
-        left.contentIndex - right.contentIndex
-        || (left.itemId ?? "").localeCompare(right.itemId ?? ""),
-    )
-
-const mergeAnnotations = (
-  existingAnnotations: unknown,
-  collectedAnnotations: Array<unknown>,
-): Array<unknown> => {
-  const annotations = getArray(existingAnnotations)
-  annotations.push(...collectedAnnotations)
-  return annotations
-}
-
-const getRecord = (value: unknown): Record<string, unknown> | undefined =>
-  value && typeof value === "object" ?
-    (value as Record<string, unknown>)
-  : undefined
-
-const getArray = (value: unknown): Array<unknown> =>
-  Array.isArray(value) ? Array.from(value as Array<unknown>) : []
 
 const getStreamErrorMessage = (
   event: Extract<ResponseStreamEvent, { type: "error" }>,
 ): string | undefined => {
   return event.error?.message ?? event.message ?? undefined
 }
-
-const getString = (value: unknown): string | undefined =>
-  typeof value === "string" ? value : undefined
 
 const createUsageRecorder = (
   payload: AnthropicMessagesPayload,
@@ -617,19 +419,17 @@ export const tryHandleWebSearch = async (
   }
 
   if (route.kind === "responses") {
-    const subagentMarker = parseSubagentMarkerFromFirstUser(payload)
     let sessionId = getRootSessionId(payload, c)
     const requestId = generateRequestIdFromPayload(payload, sessionId)
     if (!sessionId) {
       sessionId = getUUID(requestId)
     }
-    const compactType = getCompactType(payload)
     return await handleWebSearchViaResponses(c, payload, {
-      subagentMarker,
+      subagentMarker: null,
       webSearchModel: route.model,
       requestId,
       sessionId,
-      compactType,
+      compactType: 0,
       logger: options.logger,
     })
   }
@@ -724,15 +524,15 @@ export const handleWebSearchViaResponses = async (
 
   return streamSSE(c, async (stream) => {
     for (const event of buildSyntheticStreamEvents(response)) {
+      const data = JSON.stringify(event)
+      logger.debug(`Web search stream event`, data)
       await stream.writeSSE({
         event: event.type,
-        data: JSON.stringify(event),
+        data: data,
       })
     }
   })
 }
-
-// --- Synthetic SSE replay -------------------------------------------------
 
 const blockToStreamEvents = (
   block: AnthropicTextBlock | AnthropicWebSearchContentBlock,

--- a/src/routes/messages/web-search/fulfill.ts
+++ b/src/routes/messages/web-search/fulfill.ts
@@ -264,12 +264,6 @@ export const reconstructWebSearchResponse = (
   return { extract, response }
 }
 
-type WebSearchResponsesStreamEvent = ResponseStreamEvent | StreamEventRecord
-
-type StreamEventRecord = Record<string, unknown> & {
-  type: string
-}
-
 interface CollectedOutputTextPart {
   annotations: Array<unknown>
   contentIndex: number
@@ -280,19 +274,19 @@ interface CollectedOutputTextPart {
 
 interface WebSearchResponsesStreamCollection {
   createdResponse?: ResponsesResult
-  outputItemsByIndex: Map<number, StreamEventRecord>
+  outputItemsByIndex: Map<number, ResponsesResult["output"][number]>
   terminalResponse?: ResponsesResult
   textPartsByKey: Map<string, CollectedOutputTextPart>
 }
 
 export const collectWebSearchResponsesStreamResult = async ({
   errorMessagePrefix = "Web search responses stream",
-  parseEvent = parseWebSearchResponsesStreamEvent,
+  parseEvent = parseResponsesStreamEvent,
   upstreamResponse,
   logger,
 }: {
   errorMessagePrefix?: string
-  parseEvent?: (data: string) => WebSearchResponsesStreamEvent | null
+  parseEvent?: (data: string) => ResponseStreamEvent | null
   upstreamResponse: ResponsesStream
   logger: ConsolaInstance
 }): Promise<ResponsesResult> => {
@@ -313,7 +307,7 @@ export const collectWebSearchResponsesStreamResult = async ({
       continue
     }
 
-    collectWebSearchResponsesStreamEvent(parsed, state)
+    collectResponsesStreamEvent(parsed, state)
 
     if (parsed.type === "error") {
       throw new Error(
@@ -329,11 +323,11 @@ export const collectWebSearchResponsesStreamResult = async ({
   throw new Error(`${errorMessagePrefix} ended without a terminal event`)
 }
 
-const parseWebSearchResponsesStreamEvent = (
+const parseResponsesStreamEvent = (
   data: string,
-): WebSearchResponsesStreamEvent | null => {
+): ResponseStreamEvent | null => {
   try {
-    return JSON.parse(data) as WebSearchResponsesStreamEvent
+    return JSON.parse(data) as ResponseStreamEvent
   } catch {
     return null
   }
@@ -349,15 +343,14 @@ const isWebSearchResponsesStream = (
 }
 
 const isResponsesTerminalEvent = (
-  event: WebSearchResponsesStreamEvent,
-): event is WebSearchResponsesStreamEvent & {
+  event: ResponseStreamEvent,
+): event is ResponseStreamEvent & {
   response: ResponsesResult
   type: "response.completed" | "response.failed" | "response.incomplete"
 } =>
-  (event.type === "response.completed"
-    || event.type === "response.failed"
-    || event.type === "response.incomplete")
-  && getResponsesResult(event.response) !== undefined
+  event.type === "response.completed"
+  || event.type === "response.failed"
+  || event.type === "response.incomplete"
 
 const createWebSearchResponsesStreamCollection =
   (): WebSearchResponsesStreamCollection => ({
@@ -365,13 +358,13 @@ const createWebSearchResponsesStreamCollection =
     textPartsByKey: new Map(),
   })
 
-const collectWebSearchResponsesStreamEvent = (
-  event: WebSearchResponsesStreamEvent,
+const collectResponsesStreamEvent = (
+  event: ResponseStreamEvent,
   state: WebSearchResponsesStreamCollection,
 ): void => {
   switch (event.type) {
     case "response.created":
-      state.createdResponse = getResponsesResult(event.response)
+      state.createdResponse = event.response
       break
     case "response.completed":
     case "response.failed":
@@ -382,27 +375,20 @@ const collectWebSearchResponsesStreamEvent = (
       }
       break
     case "response.output_item.added":
-    case "response.output_item.done": {
-      const outputIndex = getNumber(event.output_index)
-      const item = getRecord(event.item)
-      if (outputIndex !== undefined && item) {
-        state.outputItemsByIndex.set(outputIndex, item)
-      }
+    case "response.output_item.done":
+      state.outputItemsByIndex.set(event.output_index, event.item)
       break
-    }
     case "response.output_text.delta": {
       const part = getOrCreateOutputTextPart(event, state)
-      const delta = getString(event.delta)
-      if (part && delta) {
-        part.text += delta
+      if (part && event.delta) {
+        part.text += event.delta
       }
       break
     }
     case "response.output_text.done": {
       const part = getOrCreateOutputTextPart(event, state)
-      const text = getString(event.text)
-      if (part && text !== undefined) {
-        part.text = text
+      if (part) {
+        part.text = event.text
       }
       break
     }
@@ -416,6 +402,19 @@ const collectWebSearchResponsesStreamEvent = (
     }
     case "response.content_part.done":
       collectDoneContentPart(event, state)
+      break
+    case "response.in_progress":
+    case "response.content_part.added":
+    case "response.web_search_call.in_progress":
+    case "response.web_search_call.searching":
+    case "response.web_search_call.completed":
+    case "response.reasoning_summary_part.added":
+    case "response.reasoning_summary_part.done":
+    case "response.reasoning_summary_text.delta":
+    case "response.reasoning_summary_text.done":
+      // Progress/reasoning events are intentionally ignored here; output_item,
+      // output_text/content_part.done, annotations, and terminal response are
+      // enough to rebuild the web_search result.
       break
   }
 }
@@ -442,13 +441,13 @@ const buildCollectedWebSearchOutput = (
     .sort(([leftIndex], [rightIndex]) => leftIndex - rightIndex)
     .map(([outputIndex, item]) =>
       mergeOutputItemWithCollectedText(outputIndex, item, state),
-    ) as unknown as ResponsesResult["output"]
+    )
 
 const mergeOutputItemWithCollectedText = (
   outputIndex: number,
-  item: StreamEventRecord,
+  item: ResponsesResult["output"][number],
   state: WebSearchResponsesStreamCollection,
-): StreamEventRecord => {
+): ResponsesResult["output"][number] => {
   if (item.type !== "message") {
     return item
   }
@@ -458,7 +457,7 @@ const mergeOutputItemWithCollectedText = (
     return item
   }
 
-  const content = getArray(item.content)
+  const content = item.content ? [...item.content] : []
   for (const part of collectedParts) {
     const existingPart = getRecord(content[part.contentIndex])
     content[part.contentIndex] = {
@@ -479,11 +478,10 @@ const mergeOutputItemWithCollectedText = (
 }
 
 const collectDoneContentPart = (
-  event: WebSearchResponsesStreamEvent,
+  event: Extract<ResponseStreamEvent, { type: "response.content_part.done" }>,
   state: WebSearchResponsesStreamCollection,
 ): void => {
-  const eventRecord = getRecord(event)
-  const partRecord = getRecord(eventRecord?.part)
+  const partRecord = getRecord(event.part)
   if (partRecord?.type !== "output_text") {
     return
   }
@@ -505,12 +503,14 @@ const collectDoneContentPart = (
 }
 
 const getOrCreateOutputTextPart = (
-  event: WebSearchResponsesStreamEvent,
+  event: Extract<
+    ResponseStreamEvent,
+    { content_index: number; output_index: number }
+  >,
   state: WebSearchResponsesStreamCollection,
 ): CollectedOutputTextPart | undefined => {
-  const eventRecord = getRecord(event)
-  const outputIndex = getNumber(eventRecord?.output_index)
-  const contentIndex = getNumber(eventRecord?.content_index)
+  const outputIndex = event.output_index
+  const contentIndex = event.content_index
   if (outputIndex === undefined || contentIndex === undefined) {
     return undefined
   }
@@ -521,7 +521,7 @@ const getOrCreateOutputTextPart = (
     part = {
       annotations: [],
       contentIndex,
-      itemId: getString(eventRecord?.item_id),
+      itemId: getString(event.item_id),
       outputIndex,
       text: "",
     }
@@ -552,25 +552,19 @@ const mergeAnnotations = (
   return annotations
 }
 
-const getResponsesResult = (value: unknown): ResponsesResult | undefined =>
-  getRecord(value) as ResponsesResult | undefined
-
-const getRecord = (value: unknown): StreamEventRecord | undefined =>
-  value && typeof value === "object" ? (value as StreamEventRecord) : undefined
+const getRecord = (value: unknown): Record<string, unknown> | undefined =>
+  value && typeof value === "object" ?
+    (value as Record<string, unknown>)
+  : undefined
 
 const getArray = (value: unknown): Array<unknown> =>
   Array.isArray(value) ? Array.from(value as Array<unknown>) : []
 
 const getStreamErrorMessage = (
-  event: WebSearchResponsesStreamEvent,
+  event: Extract<ResponseStreamEvent, { type: "error" }>,
 ): string | undefined => {
-  const eventRecord = getRecord(event)
-  const error = getRecord(eventRecord?.error)
-  return getString(error?.message) ?? getString(eventRecord?.message)
+  return event.error?.message ?? event.message ?? undefined
 }
-
-const getNumber = (value: unknown): number | undefined =>
-  typeof value === "number" ? value : undefined
 
 const getString = (value: unknown): string | undefined =>
   typeof value === "string" ? value : undefined

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -220,18 +220,7 @@ const handleOpenAIResponsesProviderWebSearchMessages = async (
   },
 ): Promise<Response> => {
   const { modelConfig, payload, provider, providerConfig } = options
-  const selectedModel =
-    providerConfig.name === "codex" ?
-      getCodexModels().data.find((model) => model.id === payload.model)
-    : undefined
   const responsesPayload = prepareWebSearchResponsesPayload(payload)
-  responsesPayload.stream = true
-
-  applyResponsesApiContextManagement(
-    responsesPayload,
-    selectedModel?.capabilities.limits.max_prompt_tokens,
-  )
-  compactInputByLatestCompaction(responsesPayload)
 
   debugJson(logger, "provider.messages.responses.web_search.request", {
     payload: responsesPayload,
@@ -1098,8 +1087,11 @@ const respondWebSearchProviderMessagesJson = (
   const { extract, response } = reconstructWebSearchResponse(payload, body, {
     requestId: body.id || `${provider}:${payload.model}`,
   })
-  logger.debug(
-    `provider.messages.responses.web_search: ${extract.queries.length} quer(y/ies), ${extract.sources.length} source(s)`,
+
+  debugJson(
+    logger,
+    `Web search via responses: ${extract.queries.length} quer(y/ies), ${extract.sources.length} source(s)`,
+    body,
   )
 
   if (!payload.stream) {
@@ -1108,9 +1100,11 @@ const respondWebSearchProviderMessagesJson = (
 
   return streamSSE(c, async (stream) => {
     for (const event of buildSyntheticStreamEvents(response)) {
+      const data = JSON.stringify(event)
+      logger.debug(`Web search stream event`, data)
       await stream.writeSSE({
         event: event.type,
-        data: JSON.stringify(event),
+        data: data,
       })
     }
   })

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -461,8 +461,8 @@ const createCodexResponsesWebSocketStreamChunk = (
     }
 
     return {
-      data: JSON.stringify(parsed),
       event: typeof parsed.type === "string" ? parsed.type : undefined,
+      data: JSON.stringify(parsed),
       id: typeof parsed.id === "string" ? parsed.id : undefined,
     }
   } catch {
@@ -502,8 +502,8 @@ const createResponsesErrorServerSentEventChunk = (
   }
 
   return {
-    data: JSON.stringify(errorEvent),
     event: errorEvent.type,
+    data: JSON.stringify(errorEvent),
   }
 }
 

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -87,10 +87,13 @@ export interface NamespaceTool {
 
 export type ResponseIncludable =
   | "file_search_call.results"
+  | "web_search_call.results"
+  | "web_search_call.action.sources"
   | "message.input_image.image_url"
   | "computer_call_output.output.image_url"
   | "reasoning.encrypted_content"
   | "code_interpreter_call.outputs"
+  | "message.output_text.logprobs"
 
 export interface Reasoning {
   effort?: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | null
@@ -243,6 +246,7 @@ export type ResponseOutputItem =
   | ResponseOutputFunctionCall
   | ResponseOutputToolSearchCall
   | ResponseOutputToolSearchOutput
+  | ResponseOutputWebSearchCall
   | ResponseOutputCompaction
 
 export interface ResponseOutputMessage {
@@ -294,6 +298,20 @@ export interface ResponseOutputToolSearchOutput {
   status?: "in_progress" | "completed" | "incomplete"
 }
 
+export interface ResponseOutputWebSearchCall {
+  id?: string
+  type: "web_search_call"
+  action?: {
+    query?: string
+    queries?: Array<string>
+    sources?: Array<{ type?: "url"; url: string }>
+    type?: string
+    url?: string
+    pattern?: string
+  }
+  status?: "in_progress" | "searching" | "completed" | "failed"
+}
+
 export interface ResponseOutputCompaction {
   id: string
   type: "compaction"
@@ -332,12 +350,21 @@ export type ResponseStreamEvent =
   | ResponseCompletedEvent
   | ResponseIncompleteEvent
   | ResponseCreatedEvent
+  | ResponseInProgressEvent
   | ResponseErrorEvent
   | ResponseFunctionCallArgumentsDeltaEvent
   | ResponseFunctionCallArgumentsDoneEvent
   | ResponseFailedEvent
   | ResponseOutputItemAddedEvent
   | ResponseOutputItemDoneEvent
+  | ResponseContentPartAddedEvent
+  | ResponseOutputTextAnnotationAddedEvent
+  | ResponseContentPartDoneEvent
+  | ResponseWebSearchCallInProgressEvent
+  | ResponseWebSearchCallSearchingEvent
+  | ResponseWebSearchCallCompletedEvent
+  | ResponseReasoningSummaryPartAddedEvent
+  | ResponseReasoningSummaryPartDoneEvent
   | ResponseReasoningSummaryTextDeltaEvent
   | ResponseReasoningSummaryTextDoneEvent
   | ResponseTextDeltaEvent
@@ -362,6 +389,12 @@ export interface ResponseCreatedEvent {
   response: ResponsesResult
   sequence_number: number
   type: "response.created"
+}
+
+export interface ResponseInProgressEvent {
+  response: ResponsesResult
+  sequence_number: number
+  type: "response.in_progress"
 }
 
 export interface ResponseErrorEvent {
@@ -415,6 +448,73 @@ export interface ResponseOutputItemDoneEvent {
   output_index: number
   sequence_number: number
   type: "response.output_item.done"
+}
+
+export interface ResponseContentPartAddedEvent {
+  content_index: number
+  item_id: string
+  output_index: number
+  part: ResponseOutputContentBlock
+  sequence_number: number
+  type: "response.content_part.added"
+}
+
+export interface ResponseOutputTextAnnotationAddedEvent {
+  annotation: unknown
+  annotation_index?: number
+  content_index: number
+  item_id: string
+  output_index: number
+  sequence_number: number
+  type: "response.output_text.annotation.added"
+}
+
+export interface ResponseContentPartDoneEvent {
+  content_index: number
+  item_id: string
+  output_index: number
+  part: ResponseOutputContentBlock
+  sequence_number: number
+  type: "response.content_part.done"
+}
+
+export interface ResponseWebSearchCallInProgressEvent {
+  item_id: string
+  output_index: number
+  sequence_number: number
+  type: "response.web_search_call.in_progress"
+}
+
+export interface ResponseWebSearchCallSearchingEvent {
+  item_id: string
+  output_index: number
+  sequence_number: number
+  type: "response.web_search_call.searching"
+}
+
+export interface ResponseWebSearchCallCompletedEvent {
+  item_id: string
+  output_index: number
+  sequence_number: number
+  type: "response.web_search_call.completed"
+}
+
+export interface ResponseReasoningSummaryPartAddedEvent {
+  item_id: string
+  output_index: number
+  part: ResponseReasoningBlock
+  sequence_number: number
+  summary_index: number
+  type: "response.reasoning_summary_part.added"
+}
+
+export interface ResponseReasoningSummaryPartDoneEvent {
+  item_id: string
+  output_index: number
+  part: ResponseReasoningBlock
+  sequence_number: number
+  summary_index: number
+  type: "response.reasoning_summary_part.done"
 }
 
 export interface ResponseReasoningSummaryTextDeltaEvent {

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -791,8 +791,8 @@ const createResponsesWebSocketStreamChunk = (
       parsed.message = parsed.error.message
     }
     return {
-      data: JSON.stringify(parsed),
       event: typeof parsed.type === "string" ? parsed.type : undefined,
+      data: JSON.stringify(parsed),
       id: typeof parsed.id === "string" ? parsed.id : undefined,
     }
   } catch {
@@ -830,8 +830,8 @@ const createResponsesErrorServerSentEventChunk = (
   }
 
   return {
-    data: JSON.stringify(errorEvent),
     event: errorEvent.type,
+    data: JSON.stringify(errorEvent),
   }
 }
 

--- a/tests/provider-messages-web-search.test.ts
+++ b/tests/provider-messages-web-search.test.ts
@@ -210,12 +210,7 @@ const makeResponsesStreamResponse = (body: ResponsesResult) =>
       "",
       "event: response.output_item.done",
       `data: ${JSON.stringify({
-        item: {
-          id: "msg-1",
-          role: "assistant",
-          status: "completed",
-          type: "message",
-        },
+        item: body.output[1],
         output_index: 1,
         sequence_number: 7,
         type: "response.output_item.done",

--- a/tests/web-search-fulfill.test.ts
+++ b/tests/web-search-fulfill.test.ts
@@ -266,12 +266,7 @@ async function* makeResponsesStream(result: ResponsesResult) {
   yield {
     event: "response.output_item.done",
     data: JSON.stringify({
-      item: {
-        id: "msg-1",
-        role: "assistant",
-        status: "completed",
-        type: "message",
-      },
+      item: result.output[1],
       output_index: 1,
       sequence_number: 16,
       type: "response.output_item.done",

--- a/tests/web-search-fulfill.test.ts
+++ b/tests/web-search-fulfill.test.ts
@@ -117,6 +117,90 @@ async function* makeResponsesStream(result: ResponsesResult) {
     }),
   }
   yield {
+    event: "response.in_progress",
+    data: JSON.stringify({
+      response: {
+        ...result,
+        output: [],
+        output_text: "",
+        usage: null,
+      },
+      sequence_number: 3,
+      type: "response.in_progress",
+    }),
+  }
+  yield {
+    event: "response.web_search_call.in_progress",
+    data: JSON.stringify({
+      item_id: "search-1",
+      output_index: 0,
+      sequence_number: 4,
+      type: "response.web_search_call.in_progress",
+    }),
+  }
+  yield {
+    event: "response.web_search_call.searching",
+    data: JSON.stringify({
+      item_id: "search-1",
+      output_index: 0,
+      sequence_number: 5,
+      type: "response.web_search_call.searching",
+    }),
+  }
+  yield {
+    event: "response.web_search_call.completed",
+    data: JSON.stringify({
+      item_id: "search-1",
+      output_index: 0,
+      sequence_number: 6,
+      type: "response.web_search_call.completed",
+    }),
+  }
+  yield {
+    event: "response.reasoning_summary_part.added",
+    data: JSON.stringify({
+      item_id: "reasoning-1",
+      output_index: 0,
+      part: { text: "", type: "summary_text" },
+      sequence_number: 7,
+      summary_index: 0,
+      type: "response.reasoning_summary_part.added",
+    }),
+  }
+  yield {
+    event: "response.reasoning_summary_text.delta",
+    data: JSON.stringify({
+      delta: "Searching",
+      item_id: "reasoning-1",
+      output_index: 0,
+      sequence_number: 8,
+      summary_index: 0,
+      type: "response.reasoning_summary_text.delta",
+    }),
+  }
+  yield {
+    event: "response.reasoning_summary_text.done",
+    data: JSON.stringify({
+      item_id: "reasoning-1",
+      output_index: 0,
+      sequence_number: 9,
+      summary_index: 0,
+      text: "Searching",
+      type: "response.reasoning_summary_text.done",
+    }),
+  }
+  yield {
+    event: "response.reasoning_summary_part.done",
+    data: JSON.stringify({
+      item_id: "reasoning-1",
+      output_index: 0,
+      part: { text: "Searching", type: "summary_text" },
+      sequence_number: 10,
+      summary_index: 0,
+      type: "response.reasoning_summary_part.done",
+    }),
+  }
+  yield {
     event: "response.output_item.added",
     data: JSON.stringify({
       item: {
@@ -126,8 +210,19 @@ async function* makeResponsesStream(result: ResponsesResult) {
         type: "message",
       },
       output_index: 1,
-      sequence_number: 3,
+      sequence_number: 11,
       type: "response.output_item.added",
+    }),
+  }
+  yield {
+    event: "response.content_part.added",
+    data: JSON.stringify({
+      content_index: 0,
+      item_id: "msg-1",
+      output_index: 1,
+      part: { annotations: [], text: "", type: "output_text" },
+      sequence_number: 12,
+      type: "response.content_part.added",
     }),
   }
   yield {
@@ -137,7 +232,7 @@ async function* makeResponsesStream(result: ResponsesResult) {
       delta: "Node.js 24 is the latest LTS.",
       item_id: "msg-1",
       output_index: 1,
-      sequence_number: 4,
+      sequence_number: 13,
       type: "response.output_text.delta",
     }),
   }
@@ -153,7 +248,7 @@ async function* makeResponsesStream(result: ResponsesResult) {
       content_index: 0,
       item_id: "msg-1",
       output_index: 1,
-      sequence_number: 5,
+      sequence_number: 14,
       type: "response.output_text.annotation.added",
     }),
   }
@@ -163,7 +258,7 @@ async function* makeResponsesStream(result: ResponsesResult) {
       content_index: 0,
       item_id: "msg-1",
       output_index: 1,
-      sequence_number: 6,
+      sequence_number: 15,
       text: "Node.js 24 is the latest LTS.",
       type: "response.output_text.done",
     }),
@@ -178,7 +273,7 @@ async function* makeResponsesStream(result: ResponsesResult) {
         type: "message",
       },
       output_index: 1,
-      sequence_number: 7,
+      sequence_number: 16,
       type: "response.output_item.done",
     }),
   }
@@ -190,7 +285,7 @@ async function* makeResponsesStream(result: ResponsesResult) {
         output: [],
         output_text: "",
       },
-      sequence_number: 8,
+      sequence_number: 17,
       type: "response.completed",
     }),
   }


### PR DESCRIPTION
## Feature summary

Sync 7 upstream commits from `caozhiyuan/dev` into `dev` via `czy-all`.

User-visible changes:
- Web search stream/result handling is tightened and simplified.
- Anthropic messages web search event typing is improved.
- Copilot messages avoids forwarding reasoning effort to models that do not support it.
- Anthropic `output_config` handling is enhanced for structured output payloads.
- Version bumps to 1.13.3 and 1.13.4.

Dry-run evidence before PR:
- `czy-all` fast-forwarded cleanly to `caozhiyuan/dev`.
- `caozhiyuan/dev..czy-all` was empty before push, so no buffer pollution was present.
- Local merge simulation showed no conflicts.
