### PR TITLE
sync: update from caozhiyuan/dev through v1.13.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,8 +661,14 @@ These endpoints mimic the OpenAI API structure.
 | --------------------------- | ------ | ---------------------------------------------------------------- |
 | `POST /v1/responses`        | `POST` | OpenAI Most advanced interface for generating model responses. Supports `provider/model` aliases for `openai-responses` providers. |
 | `POST /v1/chat/completions` | `POST` | Creates a model response for the given chat conversation. Supports `provider/model` aliases for `openai-compatible` providers and can be used without Copilot when the target provider is configured. |
-| `GET /v1/models`            | `GET`  | Lists Copilot models plus enabled provider models using `provider/model-id` IDs. |
+| `GET /v1/models`            | `GET`  | Lists Copilot models plus enabled provider models using `provider/model-id` IDs. Requests from Codex clients (`User-Agent` beginning with `codex`) are forwarded to the Codex Models upstream. |
 | `POST /v1/embeddings`       | `POST` | Creates an embedding vector representing the input text.         |
+
+### Codex Backend Proxy Endpoints
+
+| Endpoint             | Method | Description |
+| -------------------- | ------ | ----------- |
+| `POST /alpha/search` | `POST` | Transparently forwards the JSON body and query parameters to the Codex Alpha Search upstream. The gateway replaces client authorization and account headers with the active Codex login, forwards compatible headers such as `accept`, `content-type`, `originator`, `user-agent`, and `cookie`, and returns the upstream status, headers, and body unchanged. |
 
 ### Anthropic Compatible Endpoints
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ enabled = false
 ```
 
 > [!NOTE]
-> This configuration is specific to Codex and the GitHub Copilot provider. `name` must be set to `"OpenAI"`. It can help mitigate Codex local compact cache miss issues. If you have enabled `useResponsesApiContextManagement` (Responses API context management compaction), `remote_compaction_v2` or local compact is generally not triggered, but it may still occur when tool results return a large number of tokens.
+> This configuration is specific to Codex and the GitHub Copilot provider. `name` must be set to `"OpenAI"`. It can help mitigate Codex local compact cache miss issues. If you enable `contextManagement.responses` (Responses API context management compaction), `remote_compaction_v2` or local compact is generally not triggered, but it may still occur when tool results return a large number of tokens. Before enabling it for native Responses API traffic, check that your client supports context management compaction.
 
 ## GPT Tool Search
 
@@ -518,7 +518,10 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
       "gpt-5-mini": "<built-in exploration prompt>"
     },
     "smallModel": "gpt-5-mini",
-    "useResponsesApiContextManagement": true,
+    "contextManagement": {
+      "messages": true,
+      "responses": false
+    },
     "modelResponsesApiCompactThresholds": {
       "gpt-5.4": 217600,
       "gpt-5.5": 217600
@@ -607,7 +610,7 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
   ```
   Built-in token prices cover Codex GPT models in USD, DashScope `qwen3.7-max`, `qwen3.7-plus`, `glm-5.1`, `glm-5.2` in CNY, DeepSeek `deepseek-v4-flash`, `deepseek-v4-pro`, `deepseek-chat`, `deepseek-reasoner` in CNY, and OpenCode Go models (`glm-5.2`, `deepseek-v4-flash`, `deepseek-v4-pro`, `kimi-k2.7-code`, `mimo-v2.5`, `mimo-v2.5-pro`, `qwen3.7-plus`, `qwen3.7-max`, `minimax-m2.5`, `minimax-m3`) in USD. User `pricing` entries override built-ins. For DashScope, cached tokens are charged as explicit cache reads when the upstream usage includes `cache_creation_input_tokens`; otherwise `cachedInput` is used as the implicit cache read price. For DeepSeek, `prompt_cache_hit_tokens` map to cached input and `prompt_cache_miss_tokens` map to regular input.
 - **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests); defaults to gpt-5-mini.
-- **useResponsesApiContextManagement:** When `true`, the proxy adds Responses API `context_management` compaction instructions. Defaults to `true`. Set it to `false` to disable this globally. When enabled, the request includes `context_management` in the body and keeps only the latest compaction carrier on follow-up turns. This is especially useful for long-running tasks.
+- **contextManagement:** Controls whether the proxy adds Responses API `context_management` compaction instructions. `messages` applies when Anthropic-style `/v1/messages` requests are translated to Responses API, including `openai-responses` provider message routes, and defaults to `true`. `responses` applies to native `/v1/responses` traffic, including `provider/model` aliases and the built-in `codex` provider, and defaults to `false`. Enable `responses` only after checking that your client supports context management compaction. When enabled, the request includes `context_management` in the body and keeps only the latest compaction carrier on follow-up turns.
 - **modelResponsesApiCompactThresholds:** Per-model Responses API `compact_threshold` overrides used when the proxy adds `context_management`. These values take precedence over the fallback threshold from `resolveResponsesCompactThreshold` (`max_prompt_tokens * ratio`, or the default fallback). Defaults set `gpt-5.4` and `gpt-5.5` to `217600` (`272000 * 0.8`). Models not listed continue to use the normal fallback logic.
 - **modelReasoningEfforts:** Per-model reasoning effort applied to `/v1/messages` requests. When routed to the Copilot native Messages API it sets `output_config.effort`; when translated to the Responses API it sets `reasoning.effort`. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. If a model isn't listed, `high` is used by default; GPT-5.3+ models fall back to `xhigh` when not explicitly configured.
 - **useMessagesApi:** When `true`, Claude-family models that support Copilot's native `/v1/messages` endpoint will use the Messages API; otherwise they fall back to `/chat/completions`. Set to `false` to disable Messages API routing and always use `/chat/completions`. Defaults to `true`.

--- a/README.md
+++ b/README.md
@@ -524,7 +524,10 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
     },
     "modelResponsesApiCompactThresholds": {
       "gpt-5.4": 217600,
-      "gpt-5.5": 217600
+      "gpt-5.5": 217600,
+      "gpt-5.6-sol": 231200,
+      "gpt-5.6-terra": 231200,
+      "gpt-5.6-luna": 231200
     },
     "modelReasoningEfforts": {
       "gpt-5-mini": "low"
@@ -611,7 +614,7 @@ Use `copilot-api auth login --provider custom` to add or update another third-pa
   Built-in token prices cover Codex GPT models in USD, DashScope `qwen3.7-max`, `qwen3.7-plus`, `glm-5.1`, `glm-5.2` in CNY, DeepSeek `deepseek-v4-flash`, `deepseek-v4-pro`, `deepseek-chat`, `deepseek-reasoner` in CNY, and OpenCode Go models (`glm-5.2`, `deepseek-v4-flash`, `deepseek-v4-pro`, `kimi-k2.7-code`, `mimo-v2.5`, `mimo-v2.5-pro`, `qwen3.7-plus`, `qwen3.7-max`, `minimax-m2.5`, `minimax-m3`) in USD. User `pricing` entries override built-ins. For DashScope, cached tokens are charged as explicit cache reads when the upstream usage includes `cache_creation_input_tokens`; otherwise `cachedInput` is used as the implicit cache read price. For DeepSeek, `prompt_cache_hit_tokens` map to cached input and `prompt_cache_miss_tokens` map to regular input.
 - **smallModel:** Fallback model used for tool-less warmup messages (e.g., Claude Code probe requests); defaults to gpt-5-mini.
 - **contextManagement:** Controls whether the proxy adds Responses API `context_management` compaction instructions. `messages` applies when Anthropic-style `/v1/messages` requests are translated to Responses API, including `openai-responses` provider message routes, and defaults to `true`. `responses` applies to native `/v1/responses` traffic, including `provider/model` aliases and the built-in `codex` provider, and defaults to `false`. Enable `responses` only after checking that your client supports context management compaction. When enabled, the request includes `context_management` in the body and keeps only the latest compaction carrier on follow-up turns.
-- **modelResponsesApiCompactThresholds:** Per-model Responses API `compact_threshold` overrides used when the proxy adds `context_management`. These values take precedence over the fallback threshold from `resolveResponsesCompactThreshold` (`max_prompt_tokens * ratio`, or the default fallback). Defaults set `gpt-5.4` and `gpt-5.5` to `217600` (`272000 * 0.8`). Models not listed continue to use the normal fallback logic.
+- **modelResponsesApiCompactThresholds:** Per-model Responses API `compact_threshold` overrides used when the proxy adds `context_management`. These values take precedence over the fallback threshold from `resolveResponsesCompactThreshold` (`max_prompt_tokens * ratio`, or the default fallback). Defaults set `gpt-5.4` and `gpt-5.5` to `217600` (`272000 * 0.8`), and `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna` to `231200` (`272000 * 0.85`). Models not listed continue to use the normal fallback logic.
 - **modelReasoningEfforts:** Per-model reasoning effort applied to `/v1/messages` requests. When routed to the Copilot native Messages API it sets `output_config.effort`; when translated to the Responses API it sets `reasoning.effort`. Allowed values are `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, and `max`. If a model isn't listed, `high` is used by default; GPT-5.3+ models fall back to `xhigh` when not explicitly configured.
 - **useMessagesApi:** When `true`, Claude-family models that support Copilot's native `/v1/messages` endpoint will use the Messages API; otherwise they fall back to `/chat/completions`. Set to `false` to disable Messages API routing and always use `/chat/completions`. Defaults to `true`.
 - **useResponsesApiWebSocket:** When `true`, Responses API requests use Copilot's websocket transport for models that advertise `ws:/responses`; models that only advertise `/responses` continue to use HTTP. Set to `false` to disable websocket routing and use HTTP `/responses` whenever the selected model supports it. Defaults to `true`.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -667,8 +667,14 @@ curl http://localhost:4141/admin/config/model-mappings \
 | --- | --- | --- |
 | `POST /v1/responses` | `POST` | OpenAI 中用于生成模型响应的高级接口。支持 `openai-responses` provider 的 `provider/model` 别名。 |
 | `POST /v1/chat/completions` | `POST` | 为给定聊天对话创建模型响应。支持 `openai-compatible` provider 的 `provider/model` 别名；目标 provider 已配置时可在没有 Copilot 的情况下使用。 |
-| `GET /v1/models` | `GET` | 列出 Copilot 模型以及已启用 provider 的 `provider/model-id` 模型。 |
+| `GET /v1/models` | `GET` | 列出 Copilot 模型以及已启用 provider 的 `provider/model-id` 模型。来自 Codex 客户端（`User-Agent` 以 `codex` 开头）的请求会转发到 Codex Models 上游。 |
 | `POST /v1/embeddings` | `POST` | 创建表示输入文本的向量嵌入。 |
+
+### Codex 后端代理端点
+
+| 端点 | 方法 | 说明 |
+| --- | --- | --- |
+| `POST /alpha/search` | `POST` | 将 JSON 请求体和查询参数透明转发到 Codex Alpha Search 上游。网关会使用当前 Codex 登录态覆盖客户端的 authorization 和 account header，透传 `accept`、`content-type`、`originator`、`user-agent`、`cookie` 等兼容 header，并原样返回上游状态码、响应头和响应体。 |
 
 ### Anthropic 兼容端点
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -530,7 +530,10 @@ Copilot API 现在使用子命令结构，主要命令包括：
     },
     "modelResponsesApiCompactThresholds": {
       "gpt-5.4": 217600,
-      "gpt-5.5": 217600
+      "gpt-5.5": 217600,
+      "gpt-5.6-sol": 231200,
+      "gpt-5.6-terra": 231200,
+      "gpt-5.6-luna": 231200
     },
     "modelReasoningEfforts": {
       "gpt-5-mini": "low"
@@ -617,7 +620,7 @@ Copilot API 现在使用子命令结构，主要命令包括：
   内置 token 价格覆盖 Codex GPT 模型（USD）、DashScope `qwen3.7-max`、`qwen3.7-plus`、`glm-5.1`、`glm-5.2`（CNY），DeepSeek `deepseek-v4-flash`、`deepseek-v4-pro`、`deepseek-chat`、`deepseek-reasoner`（CNY），以及 OpenCode Go 模型（`glm-5.2`、`deepseek-v4-flash`、`deepseek-v4-pro`、`kimi-k2.7-code`、`mimo-v2.5`、`mimo-v2.5-pro`、`qwen3.7-plus`、`qwen3.7-max`、`minimax-m2.5`、`minimax-m3`，USD）。用户配置的 `pricing` 优先于内置价格。DashScope 若上游 usage 中出现 `cache_creation_input_tokens` 字段，cached tokens 按显式缓存读价计费；否则 `cachedInput` 作为隐式缓存读价。DeepSeek 的 `prompt_cache_hit_tokens` 会归入 cached input，`prompt_cache_miss_tokens` 会归入普通 input。
 - **smallModel：** 无工具预热消息的回退模型（例如 Claude Code 的探测请求）；默认是 `gpt-5-mini`。
 - **contextManagement：** 控制代理是否为 Responses API 附加 `context_management` 压缩指令。`messages` 作用于被翻译成 Responses API 的 Anthropic 风格 `/v1/messages` 请求，包括 `openai-responses` provider 的 Messages 路由，默认值为 `true`。`responses` 作用于 native `/v1/responses` 流量，包括 `provider/model` 别名和内置 `codex` provider，默认值为 `false`。只有在确认客户端支持 context management compaction 后，才建议在 Responses API 下启用 `responses`。启用后，请求体会带上 `context_management`，并在后续轮次中仅保留最新的压缩承载内容。
-- **modelResponsesApiCompactThresholds：** 按模型覆盖 Responses API 的 `compact_threshold`，仅在代理自动附加 `context_management` 时使用。它的优先级高于 `resolveResponsesCompactThreshold` 基于 `max_prompt_tokens * ratio` 的兜底阈值。默认将 `gpt-5.4` 和 `gpt-5.5` 设为 `217600`（`272000 * 0.8`）。未列出的模型继续使用原有兜底逻辑。
+- **modelResponsesApiCompactThresholds：** 按模型覆盖 Responses API 的 `compact_threshold`，仅在代理自动附加 `context_management` 时使用。它的优先级高于 `resolveResponsesCompactThreshold` 基于 `max_prompt_tokens * ratio` 的兜底阈值。默认将 `gpt-5.4` 和 `gpt-5.5` 设为 `217600`（`272000 * 0.8`），将 `gpt-5.6-sol`、`gpt-5.6-terra`、`gpt-5.6-luna` 设为 `231200`（`272000 * 0.85`）。未列出的模型继续使用原有兜底逻辑。
 - **modelReasoningEfforts：** 按模型配置的推理强度，仅作用于 `/v1/messages` 请求。当请求走 Copilot 原生 Messages API 时设置 `output_config.effort`；当请求被翻译为 Responses API 时设置 `reasoning.effort`。可选值包括 `none`、`minimal`、`low`、`medium`、`high`、`xhigh` 和 `max`。若某模型未配置，则默认使用 `high`；GPT-5.3+ 模型未显式配置时回退为 `xhigh`。
 - **useMessagesApi：** 当为 `true` 时，支持 Copilot 原生 `/v1/messages` 的 Claude 系模型会走 Messages API；否则回退到 `/chat/completions`。设为 `false` 可禁用 Messages API 路由，始终使用 `/chat/completions`。默认值为 `true`。
 - **useResponsesApiWebSocket：** 当为 `true` 时，Responses API 请求会优先对声明了 `ws:/responses` 的模型使用 Copilot websocket transport；仅声明 `/responses` 的模型仍走 HTTP。设为 `false` 可禁用 websocket 路由，并在模型支持 `/responses` 时使用 HTTP `/responses`。默认值为 `true`。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -313,7 +313,7 @@ enabled = false
 ```
 
 > [!NOTE]
-> 此配置仅限于 Codex 与 GitHub Copilot provider。`name` 一定要配置为 `"OpenAI"`。它可以缓解 Codex local compact 不命中缓存的问题。如果你已开启 `useResponsesApiContextManagement`（Responses API context management 压缩），通常不会走到 `remote_compaction_v2` 或者 local compact，但如果工具返回 tokens 过大，仍有可能触发。
+> 此配置仅限于 Codex 与 GitHub Copilot provider。`name` 一定要配置为 `"OpenAI"`。它可以缓解 Codex local compact 不命中缓存的问题。如果你开启了 `contextManagement.responses`（Responses API context management 压缩），通常不会走到 `remote_compaction_v2` 或者 local compact，但如果工具返回 tokens 过大，仍有可能触发。在 native Responses API 流量下启用前，请先确认客户端支持 context management compaction。
 
 ## GPT Tool Search
 
@@ -524,7 +524,10 @@ Copilot API 现在使用子命令结构，主要命令包括：
       "gpt-5-mini": "<built-in exploration prompt>"
     },
     "smallModel": "gpt-5-mini",
-    "useResponsesApiContextManagement": true,
+    "contextManagement": {
+      "messages": true,
+      "responses": false
+    },
     "modelResponsesApiCompactThresholds": {
       "gpt-5.4": 217600,
       "gpt-5.5": 217600
@@ -613,7 +616,7 @@ Copilot API 现在使用子命令结构，主要命令包括：
   ```
   内置 token 价格覆盖 Codex GPT 模型（USD）、DashScope `qwen3.7-max`、`qwen3.7-plus`、`glm-5.1`、`glm-5.2`（CNY），DeepSeek `deepseek-v4-flash`、`deepseek-v4-pro`、`deepseek-chat`、`deepseek-reasoner`（CNY），以及 OpenCode Go 模型（`glm-5.2`、`deepseek-v4-flash`、`deepseek-v4-pro`、`kimi-k2.7-code`、`mimo-v2.5`、`mimo-v2.5-pro`、`qwen3.7-plus`、`qwen3.7-max`、`minimax-m2.5`、`minimax-m3`，USD）。用户配置的 `pricing` 优先于内置价格。DashScope 若上游 usage 中出现 `cache_creation_input_tokens` 字段，cached tokens 按显式缓存读价计费；否则 `cachedInput` 作为隐式缓存读价。DeepSeek 的 `prompt_cache_hit_tokens` 会归入 cached input，`prompt_cache_miss_tokens` 会归入普通 input。
 - **smallModel：** 无工具预热消息的回退模型（例如 Claude Code 的探测请求）；默认是 `gpt-5-mini`。
-- **useResponsesApiContextManagement：** 当为 `true` 时，代理会为 Responses API 附加 `context_management` 压缩指令。默认值为 `true`。如需全局关闭，可设为 `false`。启用后，请求体会带上 `context_management`，并在后续轮次中仅保留最新的压缩承载内容，因此特别适合长任务场景。
+- **contextManagement：** 控制代理是否为 Responses API 附加 `context_management` 压缩指令。`messages` 作用于被翻译成 Responses API 的 Anthropic 风格 `/v1/messages` 请求，包括 `openai-responses` provider 的 Messages 路由，默认值为 `true`。`responses` 作用于 native `/v1/responses` 流量，包括 `provider/model` 别名和内置 `codex` provider，默认值为 `false`。只有在确认客户端支持 context management compaction 后，才建议在 Responses API 下启用 `responses`。启用后，请求体会带上 `context_management`，并在后续轮次中仅保留最新的压缩承载内容。
 - **modelResponsesApiCompactThresholds：** 按模型覆盖 Responses API 的 `compact_threshold`，仅在代理自动附加 `context_management` 时使用。它的优先级高于 `resolveResponsesCompactThreshold` 基于 `max_prompt_tokens * ratio` 的兜底阈值。默认将 `gpt-5.4` 和 `gpt-5.5` 设为 `217600`（`272000 * 0.8`）。未列出的模型继续使用原有兜底逻辑。
 - **modelReasoningEfforts：** 按模型配置的推理强度，仅作用于 `/v1/messages` 请求。当请求走 Copilot 原生 Messages API 时设置 `output_config.effort`；当请求被翻译为 Responses API 时设置 `reasoning.effort`。可选值包括 `none`、`minimal`、`low`、`medium`、`high`、`xhigh` 和 `max`。若某模型未配置，则默认使用 `high`；GPT-5.3+ 模型未显式配置时回退为 `xhigh`。
 - **useMessagesApi：** 当为 `true` 时，支持 Copilot 原生 `/v1/messages` 的 Claude 系模型会走 Messages API；否则回退到 `/chat/completions`。设为 `false` 可禁用 Messages API 路由，始终使用 `/chat/completions`。默认值为 `true`。

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.21",
+  "version": "1.13.22",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.24",
+  "version": "1.13.25",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.18",
+  "version": "1.13.19",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.22",
+  "version": "1.13.23",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.17",
+  "version": "1.13.18",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.23",
+  "version": "1.13.24",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.20",
+  "version": "1.13.21",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.13.19",
+  "version": "1.13.20",
   "description": "Copilot API Desktop App",
   "main": "out/main/index.js",
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.20",
+  "version": "1.13.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.20",
+      "version": "1.13.21",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.23",
+  "version": "1.13.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.23",
+      "version": "1.13.24",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.24",
+  "version": "1.13.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.24",
+      "version": "1.13.25",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.19",
+  "version": "1.13.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.19",
+      "version": "1.13.20",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.18",
+  "version": "1.13.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.18",
+      "version": "1.13.19",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.22",
+  "version": "1.13.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.22",
+      "version": "1.13.23",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.21",
+  "version": "1.13.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.21",
+      "version": "1.13.22",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.17",
+  "version": "1.13.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.13.17",
+      "version": "1.13.18",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.24",
+  "version": "1.13.25",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.22",
+  "version": "1.13.23",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.18",
+  "version": "1.13.19",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.21",
+  "version": "1.13.22",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.17",
+  "version": "1.13.18",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.20",
+  "version": "1.13.21",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.19",
+  "version": "1.13.20",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.13.23",
+  "version": "1.13.24",
   "description": "OpenAI and Anthropic-compatible gateway for GitHub Copilot or Codex or third-party providers.",
   "keywords": [
     "github-copilot",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -140,6 +140,9 @@ You interact with the user through a terminal. You have 2 ways of communicating 
 const modelResponsesApiCompactThresholds = {
   "gpt-5.4": 272_000 * 0.8,
   "gpt-5.5": 272_000 * 0.8,
+  "gpt-5.6-sol": 272_000 * 0.85,
+  "gpt-5.6-terra": 272_000 * 0.85,
+  "gpt-5.6-luna": 272_000 * 0.85,
 }
 
 const defaultContextManagement = {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -13,7 +13,7 @@ export interface AppConfig {
   modelMappings?: Record<string, string>
   extraPrompts?: Record<string, string>
   smallModel?: string
-  useResponsesApiContextManagement?: boolean
+  contextManagement?: ContextManagementConfig
   modelResponsesApiCompactThresholds?: Record<string, number>
   modelReasoningEfforts?: Record<
     string,
@@ -31,6 +31,11 @@ export interface AppConfig {
   // Mixing web_search with other tools is not supported.
   messageApiWebSearchModel?: string
   claudeTokenMultiplier?: number
+}
+
+export interface ContextManagementConfig {
+  messages?: boolean
+  responses?: boolean
 }
 
 export interface ModelConfig {
@@ -137,6 +142,11 @@ const modelResponsesApiCompactThresholds = {
   "gpt-5.5": 272_000 * 0.8,
 }
 
+const defaultContextManagement = {
+  messages: true,
+  responses: false,
+} satisfies Required<ContextManagementConfig>
+
 const defaultConfig: AppConfig = {
   auth: {
     apiKeys: [],
@@ -147,7 +157,7 @@ const defaultConfig: AppConfig = {
     "gpt-5-mini": gpt5ExplorationPrompt,
   },
   smallModel: "gpt-5-mini",
-  useResponsesApiContextManagement: true,
+  contextManagement: defaultContextManagement,
   modelResponsesApiCompactThresholds,
   modelReasoningEfforts: {
     "gpt-5-mini": "low",
@@ -265,6 +275,10 @@ function mergeDefaultConfig(config: AppConfig): {
     defaultConfig.modelResponsesApiCompactThresholds ?? {}
   const modelReasoningEfforts = config.modelReasoningEfforts ?? {}
   const defaultModelReasoningEfforts = defaultConfig.modelReasoningEfforts ?? {}
+  const contextManagement = normalizeContextManagementConfig(
+    config.contextManagement,
+  )
+  const defaultContextManagementConfig = defaultConfig.contextManagement ?? {}
 
   const missingExtraPromptModels = Object.keys(defaultExtraPrompts).filter(
     (model) => !Object.hasOwn(extraPrompts, model),
@@ -276,16 +290,21 @@ function mergeDefaultConfig(config: AppConfig): {
   const missingResponsesApiCompactThresholdModels = Object.keys(
     defaultResponsesApiCompactThresholds,
   ).filter((model) => !Object.hasOwn(responsesApiCompactThresholds, model))
+  const missingContextManagementKeys = Object.keys(
+    defaultContextManagementConfig,
+  ).filter((key) => !Object.hasOwn(contextManagement, key))
 
   const hasExtraPromptChanges = missingExtraPromptModels.length > 0
   const hasReasoningEffortChanges = missingReasoningEffortModels.length > 0
   const hasResponsesApiCompactThresholdChanges =
     missingResponsesApiCompactThresholdModels.length > 0
+  const hasContextManagementChanges = missingContextManagementKeys.length > 0
 
   if (
     !hasExtraPromptChanges
     && !hasReasoningEffortChanges
     && !hasResponsesApiCompactThresholdChanges
+    && !hasContextManagementChanges
   ) {
     return { mergedConfig: config, changed: false }
   }
@@ -293,6 +312,10 @@ function mergeDefaultConfig(config: AppConfig): {
   return {
     mergedConfig: {
       ...config,
+      contextManagement: {
+        ...defaultContextManagementConfig,
+        ...contextManagement,
+      },
       extraPrompts: {
         ...defaultExtraPrompts,
         ...extraPrompts,
@@ -307,6 +330,23 @@ function mergeDefaultConfig(config: AppConfig): {
       },
     },
     changed: true,
+  }
+}
+
+function normalizeContextManagementConfig(
+  value: ContextManagementConfig | undefined,
+): ContextManagementConfig {
+  if (!value || typeof value !== "object") {
+    return {}
+  }
+
+  return {
+    ...(typeof value.messages === "boolean" ?
+      { messages: value.messages }
+    : {}),
+    ...(typeof value.responses === "boolean" ?
+      { responses: value.responses }
+    : {}),
   }
 }
 
@@ -450,9 +490,16 @@ export function getSmallModel(): string {
   return config.smallModel ?? "gpt-5-mini"
 }
 
-export function isResponsesApiContextManagementEnabled(): boolean {
+export function isContextManagementEnabledForMessages(): boolean {
   const config = getConfig()
-  return config.useResponsesApiContextManagement ?? true
+  return config.contextManagement?.messages ?? defaultContextManagement.messages
+}
+
+export function isContextManagementEnabledForResponses(): boolean {
+  const config = getConfig()
+  return (
+    config.contextManagement?.responses ?? defaultContextManagement.responses
+  )
 }
 
 export function getModelResponsesApiCompactThreshold(

--- a/src/lib/token-usage/index.ts
+++ b/src/lib/token-usage/index.ts
@@ -249,6 +249,7 @@ export function normalizeResponsesUsage(
         input_tokens?: number
         input_tokens_details?: {
           cached_tokens?: number
+          cache_write_tokens?: number
         }
         output_tokens?: number
         total_tokens?: number
@@ -259,10 +260,16 @@ export function normalizeResponsesUsage(
   const cachedTokens = normalizeToken(
     usage?.input_tokens_details?.cached_tokens,
   )
+  const cacheWriteTokens = normalizeToken(
+    usage?.input_tokens_details?.cache_write_tokens,
+  )
   const inputTokens = normalizeToken(usage?.input_tokens)
   return {
+    ...(cacheWriteTokens > 0 && {
+      cache_creation_input_tokens: cacheWriteTokens,
+    }),
     cache_read_input_tokens: cachedTokens,
-    input_tokens: Math.max(0, inputTokens - cachedTokens),
+    input_tokens: Math.max(0, inputTokens - cachedTokens - cacheWriteTokens),
     output_tokens: normalizeToken(usage?.output_tokens),
     total_tokens: normalizeOptionalToken(usage?.total_tokens),
   }

--- a/src/lib/token-usage/pricing.ts
+++ b/src/lib/token-usage/pricing.ts
@@ -51,34 +51,100 @@ const BUILTIN_PROVIDER_PRICING: Record<
       output: 14,
     },
     "gpt-5.4": {
-      cachedInput: 0.25,
-      input: 2.5,
-      output: 15,
+      tiers: [
+        {
+          cachedInput: 0.25,
+          input: 2.5,
+          maxInputTokens: 272_000,
+          output: 15,
+        },
+        {
+          cachedInput: 0.5,
+          input: 5,
+          output: 22.5,
+        },
+      ],
     },
     "gpt-5.4-mini": {
-      cachedInput: 0.075,
-      input: 0.75,
-      output: 4.5,
+      tiers: [
+        {
+          cachedInput: 0.075,
+          input: 0.75,
+          maxInputTokens: 272_000,
+          output: 4.5,
+        },
+        {
+          cachedInput: 0.15,
+          input: 1.5,
+          output: 6.75,
+        },
+      ],
     },
     "gpt-5.5": {
-      cachedInput: 0.5,
-      input: 5,
-      output: 30,
+      tiers: [
+        {
+          cachedInput: 0.5,
+          input: 5,
+          maxInputTokens: 272_000,
+          output: 30,
+        },
+        {
+          cachedInput: 1,
+          input: 10,
+          output: 45,
+        },
+      ],
     },
     "gpt-5.6-sol": {
-      cachedInput: 0.5,
-      input: 5,
-      output: 30,
+      tiers: [
+        {
+          cacheCreationInput: 6.25,
+          cachedInput: 0.5,
+          input: 5,
+          maxInputTokens: 272_000,
+          output: 30,
+        },
+        {
+          cacheCreationInput: 12.5,
+          cachedInput: 1,
+          input: 10,
+          output: 45,
+        },
+      ],
     },
     "gpt-5.6-terra": {
-      cachedInput: 0.25,
-      input: 2.5,
-      output: 15,
+      tiers: [
+        {
+          cacheCreationInput: 3.125,
+          cachedInput: 0.25,
+          input: 2.5,
+          maxInputTokens: 272_000,
+          output: 15,
+        },
+        {
+          cacheCreationInput: 6.25,
+          cachedInput: 0.5,
+          input: 5,
+          output: 22.5,
+        },
+      ],
     },
     "gpt-5.6-luna": {
-      cachedInput: 0.1,
-      input: 1,
-      output: 6,
+      tiers: [
+        {
+          cacheCreationInput: 1.25,
+          cachedInput: 0.1,
+          input: 1,
+          maxInputTokens: 272_000,
+          output: 6,
+        },
+        {
+          cacheCreationInput: 2.5,
+          cachedInput: 0.2,
+          input: 2,
+          output: 9,
+        },
+      ],
     },
   },
   dashscope: {
@@ -398,7 +464,10 @@ function resolveCacheReadPrice(
     && input.cache_creation_input_tokens !== null
 
   if (hasCacheCreationSignal) {
-    return normalizePrice(pricing.explicitCachedInput)
+    const explicitPrice = normalizePrice(pricing.explicitCachedInput)
+    if (explicitPrice !== null) {
+      return explicitPrice
+    }
   }
 
   return normalizePrice(pricing.cachedInput)

--- a/src/routes/alpha-search/route.ts
+++ b/src/routes/alpha-search/route.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono"
+
+import { forwardError } from "~/lib/error"
+import { createHandlerLogger, debugJson } from "~/lib/logger"
+import { resolveProviderConfig } from "~/lib/provider-resolver"
+import { forwardCodexAlphaSearch } from "~/services/codex/alpha-search"
+import { createProviderProxyResponse } from "~/services/providers/provider-proxy"
+
+const logger = createHandlerLogger("alpha-search-handler")
+
+export const alphaSearchRoutes = new Hono()
+
+alphaSearchRoutes.post("/", async (c) => {
+  try {
+    const codexProviderConfig = await resolveProviderConfig("codex")
+    if (!codexProviderConfig) {
+      return c.json(
+        {
+          error: {
+            message: "Provider 'codex' not found or disabled",
+            type: "invalid_request_error",
+          },
+        },
+        404,
+      )
+    }
+
+    const requestBody = await c.req.raw.clone().text()
+    debugJson(logger, "alpha_search.codex.request", {
+      body: requestBody,
+    })
+
+    const upstreamResponse = await forwardCodexAlphaSearch(c.req.raw)
+    const responseBody = await upstreamResponse.clone().text()
+    debugJson(logger, "alpha_search.codex.response", {
+      body: responseBody,
+      statusCode: upstreamResponse.status,
+    })
+    return createProviderProxyResponse(upstreamResponse)
+  } catch (error) {
+    logger.error("alpha_search.codex.error", { error })
+    return await forwardError(c, error)
+  }
+})

--- a/src/routes/messages/api-flows.ts
+++ b/src/routes/messages/api-flows.ts
@@ -221,12 +221,17 @@ export const handleWithResponsesApi = async (
     payload: anthropicPayload,
   })
 
-  applyResponsesApiContextManagement(
+  const shouldCompactInput = applyResponsesApiContextManagement(
     responsesPayload,
     selectedModel?.capabilities.limits.max_prompt_tokens,
+    {
+      source: "messages",
+    },
   )
 
-  compactInputByLatestCompaction(responsesPayload)
+  if (shouldCompactInput) {
+    compactInputByLatestCompaction(responsesPayload)
+  }
 
   debugJson(logger, "Translated Responses payload:", responsesPayload)
 

--- a/src/routes/messages/responses-stream-translation.ts
+++ b/src/routes/messages/responses-stream-translation.ts
@@ -571,8 +571,12 @@ const messageStart = (
 ): Array<AnthropicStreamEventData> => {
   state.messageStartSent = true
   const inputCachedTokens = response.usage?.input_tokens_details?.cached_tokens
+  const cacheWriteTokens =
+    response.usage?.input_tokens_details?.cache_write_tokens
   const inputTokens =
-    (response.usage?.input_tokens ?? 0) - (inputCachedTokens ?? 0)
+    (response.usage?.input_tokens ?? 0)
+    - (inputCachedTokens ?? 0)
+    - (cacheWriteTokens ?? 0)
   return [
     {
       type: "message_start",
@@ -588,6 +592,9 @@ const messageStart = (
           input_tokens: inputTokens,
           output_tokens: 0,
           cache_read_input_tokens: inputCachedTokens ?? 0,
+          ...(cacheWriteTokens !== undefined && {
+            cache_creation_input_tokens: cacheWriteTokens,
+          }),
         },
       },
     },

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -151,6 +151,7 @@ export const translateAnthropicMessagesToResponsesPayload = (
     reasoning: {
       effort: getReasoningEffortForModel(payload.model),
       summary: "detailed",
+      context: "all_turns",
     },
     include: ["reasoning.encrypted_content"],
   }

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -1098,13 +1098,18 @@ const mapResponsesUsage = (
   const inputTokens = response.usage?.input_tokens ?? 0
   const outputTokens = response.usage?.output_tokens ?? 0
   const inputCachedTokens = response.usage?.input_tokens_details?.cached_tokens
+  const cacheWriteTokens =
+    response.usage?.input_tokens_details?.cache_write_tokens
 
   return {
-    input_tokens: inputTokens - (inputCachedTokens ?? 0),
+    input_tokens:
+      inputTokens - (inputCachedTokens ?? 0) - (cacheWriteTokens ?? 0),
     output_tokens: outputTokens,
-    ...(response.usage?.input_tokens_details?.cached_tokens !== undefined && {
-      cache_read_input_tokens:
-        response.usage.input_tokens_details.cached_tokens,
+    ...(inputCachedTokens !== undefined && {
+      cache_read_input_tokens: inputCachedTokens,
+    }),
+    ...(cacheWriteTokens !== undefined && {
+      cache_creation_input_tokens: cacheWriteTokens,
     }),
   }
 }

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -167,16 +167,9 @@ async function getAggregatedModels(
 async function logCodexModelsResponse(response: Response): Promise<void> {
   try {
     const responseText = await response.clone().text()
-    let models: unknown = responseText
-    try {
-      models = JSON.parse(responseText)
-    } catch {
-      // Keep non-JSON upstream responses visible as text.
-    }
-
     logger.debug("models.codex.response", {
       statusCode: response.status,
-      models,
+      models: responseText,
     })
   } catch (error) {
     logger.warn("models.codex.response_log_error", { error })

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono"
 
 import { listEnabledProviders } from "~/lib/config"
 import { forwardError } from "~/lib/error"
-import { createHandlerLogger } from "~/lib/logger"
+import { createHandlerLogger, debugJson } from "~/lib/logger"
 import { toClientModelId } from "~/lib/models"
 import { resolveProviderConfig } from "~/lib/provider-resolver"
 import { state } from "~/lib/state"
@@ -167,7 +167,7 @@ async function getAggregatedModels(
 async function logCodexModelsResponse(response: Response): Promise<void> {
   try {
     const responseText = await response.clone().text()
-    logger.debug("models.codex.response", {
+    debugJson(logger, "models.codex.response", {
       statusCode: response.status,
       models: responseText,
     })
@@ -195,7 +195,6 @@ modelRoutes.get("/", async (c) => {
       const upstreamResponse = await forwardCodexModels(
         c.req.url,
         c.req.raw.headers,
-        codexProviderConfig.baseUrl,
       )
       await logCodexModelsResponse(upstreamResponse)
       return createProviderProxyResponse(upstreamResponse)

--- a/src/routes/models/route.ts
+++ b/src/routes/models/route.ts
@@ -7,13 +7,20 @@ import { toClientModelId } from "~/lib/models"
 import { resolveProviderConfig } from "~/lib/provider-resolver"
 import { state } from "~/lib/state"
 import type { Model } from "~/services/copilot/get-models"
-import { getModels as getCodexModels } from "~/services/codex/get-models"
-import { forwardProviderModels } from "~/services/providers/provider-proxy"
+import {
+  forwardCodexModels,
+  getModels as getCodexModels,
+} from "~/services/codex/get-models"
+import {
+  createProviderProxyResponse,
+  forwardProviderModels,
+} from "~/services/providers/provider-proxy"
 
 export const modelRoutes = new Hono()
 
 const logger = createHandlerLogger("models-handler")
 const EPOCH_ISO = new Date(0).toISOString()
+const CODEX_USER_AGENT_PATTERN = /^codex/iu
 
 type ClientModel = Record<string, unknown> & {
   id: string
@@ -22,6 +29,10 @@ type ClientModel = Record<string, unknown> & {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isCodexUserAgent(userAgent: string | undefined): boolean {
+  return CODEX_USER_AGENT_PATTERN.test(userAgent?.trim() ?? "")
 }
 
 function normalizeCopilotModel(model: Model): ClientModel {
@@ -153,8 +164,50 @@ async function getAggregatedModels(
   })
 }
 
+async function logCodexModelsResponse(response: Response): Promise<void> {
+  try {
+    const responseText = await response.clone().text()
+    let models: unknown = responseText
+    try {
+      models = JSON.parse(responseText)
+    } catch {
+      // Keep non-JSON upstream responses visible as text.
+    }
+
+    logger.debug("models.codex.response", {
+      statusCode: response.status,
+      models,
+    })
+  } catch (error) {
+    logger.warn("models.codex.response_log_error", { error })
+  }
+}
+
 modelRoutes.get("/", async (c) => {
   try {
+    if (isCodexUserAgent(c.req.header("user-agent"))) {
+      const codexProviderConfig = await resolveProviderConfig("codex")
+      if (!codexProviderConfig) {
+        return c.json(
+          {
+            error: {
+              message: "Provider 'codex' not found or disabled",
+              type: "invalid_request_error",
+            },
+          },
+          404,
+        )
+      }
+
+      const upstreamResponse = await forwardCodexModels(
+        c.req.url,
+        c.req.raw.headers,
+        codexProviderConfig.baseUrl,
+      )
+      await logCodexModelsResponse(upstreamResponse)
+      return createProviderProxyResponse(upstreamResponse)
+    }
+
     const models = await getAggregatedModels(c.req.raw.headers)
 
     return c.json({

--- a/src/routes/provider/messages/handler.ts
+++ b/src/routes/provider/messages/handler.ts
@@ -332,11 +332,16 @@ const handleOpenAIResponsesProviderMessages = async (
     : undefined
   const responsesPayload = translateAnthropicMessagesToResponsesPayload(payload)
 
-  applyResponsesApiContextManagement(
+  const shouldCompactInput = applyResponsesApiContextManagement(
     responsesPayload,
     selectedModel?.capabilities.limits.max_prompt_tokens,
+    {
+      source: "messages",
+    },
   )
-  compactInputByLatestCompaction(responsesPayload)
+  if (shouldCompactInput) {
+    compactInputByLatestCompaction(responsesPayload)
+  }
 
   debugJson(logger, "provider.messages.responses.request", {
     payload: responsesPayload,

--- a/src/routes/provider/responses/handler.ts
+++ b/src/routes/provider/responses/handler.ts
@@ -14,10 +14,7 @@ import {
   normalizeResponsesUsage,
   type UsageTokens,
 } from "~/lib/token-usage"
-import {
-  applyResponsesApiContextManagement,
-  compactInputByLatestCompaction,
-} from "~/routes/responses/utils"
+
 import type {
   ResponsesPayload,
   ResponsesResult,
@@ -25,7 +22,6 @@ import type {
   ResponsesStream,
 } from "~/services/copilot/create-responses"
 import { forwardCodexResponses } from "~/services/codex/create-responses"
-import { getModels as getCodexModels } from "~/services/codex/get-models"
 import {
   createProviderProxyResponse,
   forwardProviderResponses,
@@ -63,22 +59,6 @@ export async function handleProviderResponsesForProvider(
     )
   }
 
-  const model =
-    providerConfig.name === "codex" ?
-      getCodexModels().data.find((model) => model.id === payload.model)
-    : undefined
-
-  const maxPromptTokens = model?.capabilities.limits.max_prompt_tokens ?? 0
-  // Smaller than the client compaction threshold, use server-side compaction to maintain cache hit rate
-  applyResponsesApiContextManagement(payload, maxPromptTokens, 0.8)
-
-  const contextManagement = payload.context_management
-  debugJson(logger, "Translated Responses request payload:", {
-    contextManagement,
-    provider,
-  })
-
-  compactInputByLatestCompaction(payload)
   const modelConfig = providerConfig.models?.[payload.model]
 
   if (providerConfig.name === "codex") {

--- a/src/routes/provider/responses/handler.ts
+++ b/src/routes/provider/responses/handler.ts
@@ -14,6 +14,10 @@ import {
   normalizeResponsesUsage,
   type UsageTokens,
 } from "~/lib/token-usage"
+import {
+  applyResponsesApiContextManagement,
+  compactInputByLatestCompaction,
+} from "~/routes/responses/utils"
 
 import type {
   ResponsesPayload,
@@ -22,6 +26,7 @@ import type {
   ResponsesStream,
 } from "~/services/copilot/create-responses"
 import { forwardCodexResponses } from "~/services/codex/create-responses"
+import { getModels as getCodexModels } from "~/services/codex/get-models"
 import {
   createProviderProxyResponse,
   forwardProviderResponses,
@@ -58,6 +63,29 @@ export async function handleProviderResponsesForProvider(
       400,
     )
   }
+
+  const model =
+    providerConfig.name === "codex" ?
+      getCodexModels().data.find((model) => model.id === payload.model)
+    : undefined
+
+  // Smaller than the client compaction threshold, use server-side compaction to maintain cache hit rate.
+  const shouldCompactInput = applyResponsesApiContextManagement(
+    payload,
+    model?.capabilities.limits.max_prompt_tokens,
+    {
+      compactThresholdRatio: 0.8,
+      source: "responses",
+    },
+  )
+  if (shouldCompactInput) {
+    compactInputByLatestCompaction(payload)
+  }
+
+  debugJson(logger, "Translated Responses request payload:", {
+    contextManagement: payload.context_management,
+    provider,
+  })
 
   const modelConfig = providerConfig.models?.[payload.model]
 

--- a/src/routes/responses/handler.ts
+++ b/src/routes/responses/handler.ts
@@ -90,8 +90,6 @@ export const handleResponses = async (c: Context) => {
     removeWebSearchTool(payload)
   }
 
-  compactInputByLatestCompaction(payload)
-
   const selectedModel = state.models?.data.find(
     (model) => model.id === payload.model,
   )
@@ -122,7 +120,17 @@ export const handleResponses = async (c: Context) => {
 
   // Smaller than the client compaction threshold, use server-side compaction to maintain cache hit rate
   const maxPromptTokens = selectedModel?.capabilities.limits.max_prompt_tokens
-  applyResponsesApiContextManagement(payload, maxPromptTokens, 0.8)
+  const shouldCompactInput = applyResponsesApiContextManagement(
+    payload,
+    maxPromptTokens,
+    {
+      compactThresholdRatio: 0.8,
+      source: "responses",
+    },
+  )
+  if (shouldCompactInput) {
+    compactInputByLatestCompaction(payload)
+  }
 
   debugJson(logger, "Translated Responses payload:", payload)
 

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -308,7 +308,7 @@ export const applyResponsesApiContextManagement = (
   },
 ): boolean => {
   if (hasTerminalCompactionTrigger(payload)) {
-    return false
+    return isContextManagementEnabledForSource(options.source)
   }
 
   if (payload.context_management !== undefined) {

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -18,7 +18,7 @@ import {
 
 export const RESPONSES_ENDPOINT = "/responses"
 export const RESPONSES_WS_ENDPOINT = "ws:/responses"
-export const DEFAULT_RESPONSES_COMPACT_THRESHOLD_RATIO = 0.9
+export const DEFAULT_RESPONSES_COMPACT_THRESHOLD_RATIO = 0.85
 
 export const responsesUtilsDependencies = {
   getModelResponsesApiCompactThreshold:

--- a/src/routes/responses/utils.ts
+++ b/src/routes/responses/utils.ts
@@ -12,19 +12,23 @@ import type {
 import { COMPACT_REQUEST, type CompactType } from "~/lib/compact"
 import {
   getModelResponsesApiCompactThreshold as getConfiguredModelResponsesApiCompactThreshold,
-  isResponsesApiContextManagementEnabled as isConfiguredResponsesApiContextManagementEnabled,
+  isContextManagementEnabledForMessages as isConfiguredContextManagementEnabledForMessages,
+  isContextManagementEnabledForResponses as isConfiguredContextManagementEnabledForResponses,
   isResponsesApiWebSocketEnabled as isConfiguredResponsesApiWebSocketEnabled,
 } from "~/lib/config"
 
 export const RESPONSES_ENDPOINT = "/responses"
 export const RESPONSES_WS_ENDPOINT = "ws:/responses"
 export const DEFAULT_RESPONSES_COMPACT_THRESHOLD_RATIO = 0.85
+export type ResponsesApiContextManagementSource = "messages" | "responses"
 
 export const responsesUtilsDependencies = {
   getModelResponsesApiCompactThreshold:
     getConfiguredModelResponsesApiCompactThreshold,
-  isResponsesApiContextManagementEnabled:
-    isConfiguredResponsesApiContextManagementEnabled,
+  isContextManagementEnabledForMessages:
+    isConfiguredContextManagementEnabledForMessages,
+  isContextManagementEnabledForResponses:
+    isConfiguredContextManagementEnabledForResponses,
   isResponsesApiWebSocketEnabled: isConfiguredResponsesApiWebSocketEnabled,
 }
 
@@ -297,19 +301,22 @@ const createCompactionContextManagement = (
 
 export const applyResponsesApiContextManagement = (
   payload: ResponsesPayload,
-  maxPromptTokens?: number,
-  compactThresholdRatio = DEFAULT_RESPONSES_COMPACT_THRESHOLD_RATIO,
-): void => {
+  maxPromptTokens: number | undefined,
+  options: {
+    compactThresholdRatio?: number
+    source: ResponsesApiContextManagementSource
+  },
+): boolean => {
   if (hasTerminalCompactionTrigger(payload)) {
-    return
+    return false
   }
 
   if (payload.context_management !== undefined) {
-    return
+    return true
   }
 
-  if (!responsesUtilsDependencies.isResponsesApiContextManagementEnabled()) {
-    return
+  if (!isContextManagementEnabledForSource(options.source)) {
+    return false
   }
 
   const modelCompactThreshold = getModelResponsesApiCompactThreshold(
@@ -319,9 +326,21 @@ export const applyResponsesApiContextManagement = (
     modelCompactThreshold
       ?? resolveResponsesCompactThreshold(
         maxPromptTokens,
-        compactThresholdRatio,
+        options.compactThresholdRatio
+          ?? DEFAULT_RESPONSES_COMPACT_THRESHOLD_RATIO,
       ),
   )
+  return true
+}
+
+const isContextManagementEnabledForSource = (
+  source: ResponsesApiContextManagementSource,
+): boolean => {
+  if (source === "messages") {
+    return responsesUtilsDependencies.isContextManagementEnabledForMessages()
+  }
+
+  return responsesUtilsDependencies.isContextManagementEnabledForResponses()
 }
 
 const hasTerminalCompactionTrigger = (payload: ResponsesPayload): boolean => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import {
 } from "./lib/request-auth"
 import { traceIdMiddleware } from "./lib/trace"
 import { zstdDecompressionMiddleware } from "./lib/zstd-request"
+import { alphaSearchRoutes } from "./routes/alpha-search/route"
 import { completionRoutes } from "./routes/chat-completions/route"
 import { configRoutes } from "./routes/admin/config/route"
 import { embeddingRoutes } from "./routes/embeddings/route"
@@ -58,6 +59,7 @@ server.route("/usage", usageRoute)
 server.route("/token-usage", tokenUsageRoute)
 server.route("/token", tokenRoute)
 server.route("/responses", responsesRoutes)
+server.route("/alpha/search", alphaSearchRoutes)
 
 // Compatibility with tools that expect v1/ prefix
 server.route("/v1/chat/completions", completionRoutes)

--- a/src/services/codex/alpha-search.ts
+++ b/src/services/codex/alpha-search.ts
@@ -1,0 +1,32 @@
+import {
+  buildCodexRequestHeaders,
+  CODEX_API_BASE_URL,
+} from "~/services/codex/create-responses"
+
+const CODEX_ALPHA_SEARCH_URL = `${CODEX_API_BASE_URL}/codex/alpha/search`
+
+export function resolveCodexAlphaSearchUrl(requestUrl: string): string {
+  const upstreamUrl = new URL(CODEX_ALPHA_SEARCH_URL)
+  upstreamUrl.search = new URL(requestUrl, "http://localhost").search
+  return upstreamUrl.toString()
+}
+
+export async function forwardCodexAlphaSearch(
+  request: Request,
+): Promise<Response> {
+  const headers = buildCodexRequestHeaders(request.headers)
+  if (!headers.has("accept")) {
+    headers.set("accept", "application/json")
+  }
+
+  const body = await request.arrayBuffer()
+  if (!headers.has("content-type")) {
+    headers.set("content-type", "application/json")
+  }
+
+  return await fetch(resolveCodexAlphaSearchUrl(request.url), {
+    method: "POST",
+    headers,
+    body,
+  })
+}

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -154,13 +154,6 @@ export function buildCodexResponsesHeaders(
     options.stream ? "text/event-stream" : "application/json",
   )
   setDefaultCodexHeader(headers, "content-type", "application/json")
-  if (options.stream) {
-    setDefaultCodexHeader(
-      headers,
-      "openai-beta",
-      "responses_websockets=2026-02-06",
-    )
-  }
   return headers
 }
 
@@ -189,6 +182,11 @@ export function buildCodexResponsesWebSocketHeaders(
   requestHeaders: Headers,
 ): Record<string, string> {
   const headers = buildCodexResponsesHeaders(requestHeaders)
+  setDefaultCodexHeader(
+    headers,
+    "openai-beta",
+    "responses_websockets=2026-02-06",
+  )
   for (const headerName of STRIPPED_CODEX_WEBSOCKET_HEADERS) {
     headers.delete(headerName)
   }

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -146,18 +146,24 @@ export function buildCodexResponsesHeaders(
   requestHeaders: Headers,
   options: CodexResponsesHeaderOptions = {},
 ): Headers {
-  const { accessToken, accountId } = requireCodexAuthContext()
-  const headers = buildForwardedCodexRequestHeaders(requestHeaders)
+  const headers = buildCodexRequestHeaders(requestHeaders)
 
   setDefaultCodexHeader(
     headers,
     "accept",
     options.stream ? "text/event-stream" : "application/json",
   )
-  headers.set("authorization", `Bearer ${accessToken}`)
-  headers.set("chatgpt-account-id", accountId)
   setDefaultCodexHeader(headers, "content-type", "application/json")
   setDefaultCodexHeader(headers, "OpenAI-Beta", "responses=experimental")
+  return headers
+}
+
+export function buildCodexRequestHeaders(requestHeaders: Headers): Headers {
+  const { accessToken, accountId } = requireCodexAuthContext()
+  const headers = buildForwardedCodexRequestHeaders(requestHeaders)
+
+  headers.set("authorization", `Bearer ${accessToken}`)
+  headers.set("chatgpt-account-id", accountId)
   setDefaultCodexHeader(headers, "originator", "copilot-api")
   setDefaultCodexHeader(headers, "user-agent", "copilot-api")
   applyOpencodeCodexHeaders(headers)

--- a/src/services/codex/create-responses.ts
+++ b/src/services/codex/create-responses.ts
@@ -154,7 +154,13 @@ export function buildCodexResponsesHeaders(
     options.stream ? "text/event-stream" : "application/json",
   )
   setDefaultCodexHeader(headers, "content-type", "application/json")
-  setDefaultCodexHeader(headers, "OpenAI-Beta", "responses=experimental")
+  if (options.stream) {
+    setDefaultCodexHeader(
+      headers,
+      "openai-beta",
+      "responses_websockets=2026-02-06",
+    )
+  }
   return headers
 }
 

--- a/src/services/codex/get-models.ts
+++ b/src/services/codex/get-models.ts
@@ -1,4 +1,8 @@
 import type { Model, ModelsResponse } from "~/services/copilot/get-models"
+import {
+  buildCodexRequestHeaders,
+  CODEX_API_BASE_URL,
+} from "~/services/codex/create-responses"
 
 interface CodexModelDefinition {
   contextWindow: number
@@ -38,27 +42,55 @@ const CODEX_MODELS: Array<CodexModelDefinition> = [
     name: "GPT-5.5",
   },
   {
-    contextWindow: 272_000,
+    contextWindow: 372_000,
     id: "gpt-5.6-sol",
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.6 Sol",
   },
   {
-    contextWindow: 272_000,
+    contextWindow: 372_000,
     id: "gpt-5.6-terra",
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.6 Terra",
   },
   {
-    contextWindow: 272_000,
+    contextWindow: 372_000,
     id: "gpt-5.6-luna",
     input: ["text", "image"],
     maxTokens: 128_000,
     name: "GPT-5.6 Luna",
   },
 ]
+
+export function resolveCodexModelsUrl(
+  requestUrl: string,
+  baseUrl: string = CODEX_API_BASE_URL,
+): string {
+  const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/u, "")
+  const codexBaseUrl = normalizedBaseUrl || CODEX_API_BASE_URL
+  const modelsUrl = `${codexBaseUrl.replace(/\/codex(?:\/models)?$/u, "")}/codex/models`
+  const upstreamUrl = new URL(modelsUrl)
+  upstreamUrl.search = new URL(requestUrl, "http://localhost").search
+  return upstreamUrl.toString()
+}
+
+export async function forwardCodexModels(
+  requestUrl: string,
+  requestHeaders: Headers,
+  baseUrl: string = CODEX_API_BASE_URL,
+): Promise<Response> {
+  const headers = buildCodexRequestHeaders(requestHeaders)
+  if (!headers.has("accept")) {
+    headers.set("accept", "application/json")
+  }
+
+  return await fetch(resolveCodexModelsUrl(requestUrl, baseUrl), {
+    method: "GET",
+    headers,
+  })
+}
 
 function normalizeCodexModel(model: CodexModelDefinition): Model {
   const supportsVision = model.input.includes("image")

--- a/src/services/codex/get-models.ts
+++ b/src/services/codex/get-models.ts
@@ -64,14 +64,10 @@ const CODEX_MODELS: Array<CodexModelDefinition> = [
   },
 ]
 
-export function resolveCodexModelsUrl(
-  requestUrl: string,
-  baseUrl: string = CODEX_API_BASE_URL,
-): string {
-  const normalizedBaseUrl = baseUrl.trim().replace(/\/+$/u, "")
-  const codexBaseUrl = normalizedBaseUrl || CODEX_API_BASE_URL
-  const modelsUrl = `${codexBaseUrl.replace(/\/codex(?:\/models)?$/u, "")}/codex/models`
-  const upstreamUrl = new URL(modelsUrl)
+const CODEX_MODELS_URL = `${CODEX_API_BASE_URL}/codex/models`
+
+export function resolveCodexModelsUrl(requestUrl: string): string {
+  const upstreamUrl = new URL(CODEX_MODELS_URL)
   upstreamUrl.search = new URL(requestUrl, "http://localhost").search
   return upstreamUrl.toString()
 }
@@ -79,14 +75,13 @@ export function resolveCodexModelsUrl(
 export async function forwardCodexModels(
   requestUrl: string,
   requestHeaders: Headers,
-  baseUrl: string = CODEX_API_BASE_URL,
 ): Promise<Response> {
   const headers = buildCodexRequestHeaders(requestHeaders)
   if (!headers.has("accept")) {
     headers.set("accept", "application/json")
   }
 
-  return await fetch(resolveCodexModelsUrl(requestUrl, baseUrl), {
+  return await fetch(resolveCodexModelsUrl(requestUrl), {
     method: "GET",
     headers,
   })

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -348,6 +348,7 @@ export interface ResponseUsage {
   total_tokens: number
   input_tokens_details?: {
     cached_tokens: number
+    cache_write_tokens?: number
   }
   output_tokens_details?: {
     reasoning_tokens: number

--- a/src/services/copilot/create-responses.ts
+++ b/src/services/copilot/create-responses.ts
@@ -106,6 +106,7 @@ export interface Reasoning {
     | "max"
     | null
   summary?: "auto" | "concise" | "detailed" | null
+  context?: "auto" | "current_turn" | "all_turns" | null
 }
 
 export interface ResponseContextManagementCompactionItem {

--- a/src/services/responses-websocket.ts
+++ b/src/services/responses-websocket.ts
@@ -349,11 +349,13 @@ const createWebSocketMessageStream = async function* <TChunk>(
   }
 
   const onClose = () => {
+    consola.debug("WebSocket closed")
     closed = true
     wake()
   }
 
   const onError = (event: WebSocketErrorEvent) => {
+    consola.error("WebSocket error:", event, event.error)
     error = createWebSocketError(options.streamErrorMessage, event)
     wake()
   }
@@ -430,7 +432,6 @@ const isTextReadable = (
 
 const toError = (value: unknown): Error => {
   if (value instanceof Error) {
-    consola.error("Responses websocket error", value)
     return value
   }
 

--- a/tests/alpha-search.test.ts
+++ b/tests/alpha-search.test.ts
@@ -238,20 +238,4 @@ describe("Codex alpha search forwarding", () => {
     })
     expect(fetchMock).not.toHaveBeenCalled()
   })
-
-  test("converts forwarding failures into gateway errors", async () => {
-    state.codexAccessToken = undefined
-
-    const response = await createApp().request("/alpha/search?q=bun", {
-      method: "POST",
-    })
-
-    expect(response.status).toBe(500)
-    const body = (await response.json()) as {
-      error: { message: string; type: string }
-    }
-    expect(body.error.message).toBe("Codex access token is not loaded")
-    expect(body.error.type).toBe("error")
-    expect(fetchMock).not.toHaveBeenCalled()
-  })
 })

--- a/tests/alpha-search.test.ts
+++ b/tests/alpha-search.test.ts
@@ -1,0 +1,257 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+
+import type { ResolvedProviderConfig } from "../src/lib/config"
+
+const actualConfigModule = await import("../src/lib/config")
+const actualTokenModule = await import("../src/lib/token")
+
+let codexProviderConfig: ResolvedProviderConfig | null = null
+
+await mock.module("~/lib/config", () => ({
+  ...actualConfigModule,
+  getProviderConfig: (provider: string) =>
+    provider === "codex" ? codexProviderConfig : null,
+  getRawProviderConfig: (provider: string) =>
+    provider === "codex" ? codexProviderConfig : null,
+}))
+
+await mock.module("~/lib/token", () => ({
+  ...actualTokenModule,
+  setupCodexToken: async () => {},
+}))
+
+const { state } = await import("../src/lib/state")
+const { forwardCodexAlphaSearch, resolveCodexAlphaSearchUrl } = await import(
+  "../src/services/codex/alpha-search"
+)
+const { forwardCodexModels, getModels, resolveCodexModelsUrl } = await import(
+  "../src/services/codex/get-models"
+)
+const { alphaSearchRoutes } = await import("../src/routes/alpha-search/route")
+
+const originalFetch = globalThis.fetch
+const alphaSearchPayload = {
+  id: "search-request-id",
+  model: "gpt-5.6-sol",
+  input: [
+    {
+      type: "message",
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: "search query",
+        },
+      ],
+      internal_chat_message_metadata_passthrough: {
+        turn_id: "turn-id",
+      },
+    },
+    {
+      type: "message",
+      role: "assistant",
+      content: [
+        {
+          type: "output_text",
+          text: "searching",
+        },
+      ],
+      phase: "commentary",
+      internal_chat_message_metadata_passthrough: {
+        turn_id: "turn-id",
+      },
+    },
+  ],
+  commands: {
+    open: [{ ref_id: "turn0search0" }],
+    response_length: "long",
+  },
+  settings: {
+    allowed_callers: ["direct"],
+    external_web_access: false,
+  },
+  max_output_tokens: 10_000,
+}
+const fetchMock = mock(
+  (_url: string | URL | Request, _init?: RequestInit): Promise<Response> =>
+    Promise.resolve(
+      new Response(JSON.stringify({ results: [{ title: "result" }] }), {
+        headers: {
+          "content-type": "application/json",
+          "x-upstream": "codex",
+        },
+        status: 200,
+      }),
+    ),
+)
+
+function createApp() {
+  const app = new Hono()
+  app.route("/alpha/search", alphaSearchRoutes)
+  return app
+}
+
+beforeEach(() => {
+  codexProviderConfig = {
+    apiKey: "unused-provider-key",
+    authType: "oauth2",
+    baseUrl: "https://chatgpt.com/backend-api",
+    name: "codex",
+    type: "openai-responses",
+  }
+  state.codexAccessToken = "codex-access-token"
+  state.codexAccountId = "account-123"
+  fetchMock.mockClear()
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
+    fetchMock as unknown as typeof fetch
+})
+
+afterEach(() => {
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
+  state.codexAccessToken = undefined
+  state.codexAccountId = undefined
+})
+
+describe("Codex alpha search URL", () => {
+  test("builds the upstream URL and preserves query parameters", () => {
+    expect(
+      resolveCodexAlphaSearchUrl("http://localhost/alpha/search?q=bun&page=2"),
+    ).toBe("https://chatgpt.com/backend-api/codex/alpha/search?q=bun&page=2")
+  })
+
+  test("uses the fixed Codex API base URL", () => {
+    expect(resolveCodexAlphaSearchUrl("/alpha/search")).toBe(
+      "https://chatgpt.com/backend-api/codex/alpha/search",
+    )
+  })
+})
+
+describe("Codex models forwarding", () => {
+  test("uses the fixed Codex models URL and preserves query parameters", () => {
+    expect(
+      resolveCodexModelsUrl("http://localhost/v1/models?client=codex"),
+    ).toBe("https://chatgpt.com/backend-api/codex/models?client=codex")
+  })
+
+  test("forwards model requests with Codex auth headers", async () => {
+    await forwardCodexModels(
+      "http://localhost/v1/models?client=codex",
+      new Headers({ accept: "*/*" }),
+    )
+
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe(
+      "https://chatgpt.com/backend-api/codex/models?client=codex",
+    )
+    expect(init?.method).toBe("GET")
+    const headers = new Headers(init?.headers)
+    expect(headers.get("accept")).toBe("*/*")
+    expect(headers.get("authorization")).toBe("Bearer codex-access-token")
+    expect(headers.get("chatgpt-account-id")).toBe("account-123")
+  })
+
+  test("keeps the built-in Codex model catalog available", () => {
+    const models = getModels()
+    expect(models.object).toBe("list")
+    expect(models.data.map((model) => model.id)).toContain("gpt-5.6-sol")
+  })
+})
+
+describe("Codex alpha search forwarding", () => {
+  test("forwards POST body, query, and Codex auth headers", async () => {
+    const response = await createApp().request(
+      "/alpha/search?q=typescript&limit=5",
+      {
+        method: "POST",
+        headers: {
+          accept: "*/*",
+          authorization: "Bearer client-token",
+          "content-type": "application/json",
+          cookie: "session=test-cookie",
+          originator: "codex-tui",
+          "user-agent": "codex-tui/test",
+          "x-client-header": "kept",
+        },
+        body: JSON.stringify(alphaSearchPayload),
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("x-upstream")).toBe("codex")
+    expect(await response.json()).toEqual({
+      results: [{ title: "result" }],
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0] ?? []
+    expect(url).toBe(
+      "https://chatgpt.com/backend-api/codex/alpha/search?q=typescript&limit=5",
+    )
+    expect(init?.method).toBe("POST")
+    const headers = new Headers(init?.headers)
+    expect(headers.get("authorization")).toBe("Bearer codex-access-token")
+    expect(headers.get("chatgpt-account-id")).toBe("account-123")
+    expect(headers.get("accept")).toBe("*/*")
+    expect(headers.get("content-type")).toBe("application/json")
+    expect(headers.get("cookie")).toBe("session=test-cookie")
+    expect(headers.get("originator")).toBe("codex-tui")
+    expect(headers.get("user-agent")).toBe("codex-tui/test")
+    expect(headers.get("x-client-header")).toBe("kept")
+    expect(await new Response(init?.body).json()).toEqual(alphaSearchPayload)
+  })
+
+  test("does not expose alpha search over GET", async () => {
+    const response = await createApp().request("/alpha/search?q=bun")
+
+    expect(response.status).toBe(404)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("adds JSON content type when a request body has none", async () => {
+    await forwardCodexAlphaSearch(
+      new Request("http://localhost/alpha/search", {
+        method: "POST",
+        body: new Uint8Array([123, 125]),
+      }),
+    )
+
+    const [, init] = fetchMock.mock.calls[0] ?? []
+    expect(new Headers(init?.headers).get("content-type")).toBe(
+      "application/json",
+    )
+  })
+
+  test("returns 404 when the Codex provider is unavailable", async () => {
+    codexProviderConfig = null
+
+    const response = await createApp().request("/alpha/search?q=bun", {
+      method: "POST",
+    })
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({
+      error: {
+        message: "Provider 'codex' not found or disabled",
+        type: "invalid_request_error",
+      },
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("converts forwarding failures into gateway errors", async () => {
+    state.codexAccessToken = undefined
+
+    const response = await createApp().request("/alpha/search?q=bun", {
+      method: "POST",
+    })
+
+    expect(response.status).toBe(500)
+    const body = (await response.json()) as {
+      error: { message: string; type: string }
+    }
+    expect(body.error.message).toBe("Codex access token is not loaded")
+    expect(body.error.type).toBe("error")
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/tests/builtin-provider-config.test.ts
+++ b/tests/builtin-provider-config.test.ts
@@ -127,28 +127,6 @@ describe("builtin provider config", () => {
     })
   })
 
-  test("adds model Responses API compact thresholds by default", () => {
-    const tempDir = createTempConfigDir()
-    const configPath = path.join(tempDir, "config.json")
-
-    const output = runScript(
-      tempDir,
-      'const { getModelResponsesApiCompactThreshold } = await import("./src/lib/config"); console.log(JSON.stringify({ gpt54: getModelResponsesApiCompactThreshold("gpt-5.4"), gpt55: getModelResponsesApiCompactThreshold("gpt-5.5"), unknown: getModelResponsesApiCompactThreshold("gpt-test") ?? null }));',
-    )
-
-    expect(JSON.parse(output)).toEqual({
-      gpt54: 217600,
-      gpt55: 217600,
-      unknown: null,
-    })
-    expect(
-      readConfigFile(configPath).modelResponsesApiCompactThresholds,
-    ).toEqual({
-      "gpt-5.4": 217600,
-      "gpt-5.5": 217600,
-    })
-  })
-
   test("does not add quick provider templates by default", () => {
     const tempDir = createTempConfigDir()
     const configPath = path.join(tempDir, "config.json")

--- a/tests/builtin-provider-config.test.ts
+++ b/tests/builtin-provider-config.test.ts
@@ -6,10 +6,13 @@ import { fileURLToPath } from "node:url"
 
 interface ConfigFileShape {
   builtinProviders?: Record<string, unknown>
+  contextManagement?: {
+    messages?: boolean
+    responses?: boolean
+  }
   extraPrompts?: Record<string, string>
   modelReasoningEfforts?: Record<string, string>
   modelResponsesApiCompactThresholds?: Record<string, number>
-  useResponsesApiContextManagement?: boolean
   providers?: Record<
     string,
     {
@@ -85,33 +88,43 @@ describe("builtin provider config", () => {
     expect(readConfigFile(configPath).builtinProviders).toBeUndefined()
   })
 
-  test("enables Responses API context management by default", () => {
+  test("uses context management defaults by endpoint", () => {
     const tempDir = createTempConfigDir()
     const configPath = path.join(tempDir, "config.json")
 
     const output = runScript(
       tempDir,
-      'const { isResponsesApiContextManagementEnabled } = await import("./src/lib/config"); console.log(JSON.stringify({ enabled: isResponsesApiContextManagementEnabled() }));',
+      'const { isContextManagementEnabledForMessages, isContextManagementEnabledForResponses } = await import("./src/lib/config"); console.log(JSON.stringify({ messages: isContextManagementEnabledForMessages(), responses: isContextManagementEnabledForResponses() }));',
     )
 
-    expect(JSON.parse(output)).toEqual({ enabled: true })
-    expect(readConfigFile(configPath).useResponsesApiContextManagement).toBe(
-      true,
-    )
+    expect(JSON.parse(output)).toEqual({
+      messages: true,
+      responses: false,
+    })
+    expect(readConfigFile(configPath).contextManagement).toEqual({
+      messages: true,
+      responses: false,
+    })
   })
 
-  test("allows disabling Responses API context management", () => {
+  test("allows overriding context management per endpoint", () => {
     const tempDir = createTempConfigDir()
     writeConfigFile(tempDir, {
-      useResponsesApiContextManagement: false,
+      contextManagement: {
+        messages: false,
+        responses: true,
+      },
     })
 
     const output = runScript(
       tempDir,
-      'const { isResponsesApiContextManagementEnabled } = await import("./src/lib/config"); console.log(JSON.stringify({ enabled: isResponsesApiContextManagementEnabled() }));',
+      'const { isContextManagementEnabledForMessages, isContextManagementEnabledForResponses } = await import("./src/lib/config"); console.log(JSON.stringify({ messages: isContextManagementEnabledForMessages(), responses: isContextManagementEnabledForResponses() }));',
     )
 
-    expect(JSON.parse(output)).toEqual({ enabled: false })
+    expect(JSON.parse(output)).toEqual({
+      messages: false,
+      responses: true,
+    })
   })
 
   test("adds model Responses API compact thresholds by default", () => {

--- a/tests/codex-create-responses.test.ts
+++ b/tests/codex-create-responses.test.ts
@@ -142,7 +142,6 @@ describe("codex api helpers", () => {
     expect(headers.get("chatgpt-account-id")).toBe("codex-account")
     expect(headers.get("accept")).toBe("application/json")
     expect(headers.get("content-type")).toBe("application/json")
-    expect(headers.get("openai-beta")).toBe("responses=experimental")
     expect(headers.get("originator")).toBe("copilot-api")
     expect(headers.get("user-agent")).toBe("copilot-api")
   })

--- a/tests/codex-create-responses.test.ts
+++ b/tests/codex-create-responses.test.ts
@@ -170,6 +170,7 @@ describe("codex api helpers", () => {
 
     expect(headers.get("accept")).toBe("text/event-stream")
     expect(headers.get("cf-ray")).toBeNull()
+    expect(headers.get("openai-beta")).toBeNull()
     expect(headers.get("originator")).toBe("opencode")
     expect(headers.get("session-id")).toBe("opencode-session")
   })
@@ -200,6 +201,9 @@ describe("codex api helpers", () => {
     expect(request.headers.accept).toBeUndefined()
     expect(request.headers["content-type"]).toBeUndefined()
     expect(request.headers.authorization).toBe("Bearer codex-token")
+    expect(request.headers["openai-beta"]).toBe(
+      "responses_websockets=2026-02-06",
+    )
   })
 
   test("returns the static codex model catalog", () => {

--- a/tests/messages-api-flows.test.ts
+++ b/tests/messages-api-flows.test.ts
@@ -111,6 +111,11 @@ beforeEach(async () => {
   messagesApiFlowDependencies.createChatCompletions = createChatCompletions
   messagesApiFlowDependencies.createMessages = createMessages
   messagesApiFlowDependencies.createResponses = createResponses
+  responsesUtilsDependencies.getModelResponsesApiCompactThreshold = () =>
+    undefined
+  responsesUtilsDependencies.isContextManagementEnabledForMessages = () => true
+  responsesUtilsDependencies.isContextManagementEnabledForResponses = () =>
+    false
   responsesUtilsDependencies.isResponsesApiWebSocketEnabled = () =>
     responsesApiWebSocketEnabled
   createChatCompletions.mockClear()
@@ -504,6 +509,29 @@ test("messages Responses flow uses websocket transport by default for dual-endpo
   expect(response.status).toBe(200)
   expect(createResponses).toHaveBeenCalledTimes(1)
   expect(capturedResponsesOptions?.transport).toBe("websocket")
+})
+
+test("messages Responses flow adds context management by default", async () => {
+  const payload: AnthropicMessagesPayload = {
+    max_tokens: 128,
+    messages: [{ role: "user", content: "hello" }],
+    model: "gpt-test",
+  }
+
+  const response = await handleWithResponsesApi(createContext(), payload, {
+    logger,
+    requestId: "request-1",
+    selectedModel: createModel(["/responses"]),
+  })
+
+  expect(response.status).toBe(200)
+  expect(createResponses).toHaveBeenCalledTimes(1)
+  expect(capturedResponsesPayload?.context_management).toEqual([
+    {
+      type: "compaction",
+      compact_threshold: 108800,
+    },
+  ])
 })
 
 test("messages Responses flow keeps HTTP transport for dual-endpoint models when websocket is disabled", async () => {

--- a/tests/models-route.test.ts
+++ b/tests/models-route.test.ts
@@ -114,6 +114,8 @@ beforeEach(() => {
 afterEach(() => {
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
   state.models = undefined
+  state.codexAccessToken = undefined
+  state.codexAccountId = undefined
 })
 
 describe("model routes", () => {
@@ -191,5 +193,36 @@ describe("model routes", () => {
     expect(body.data.map((model) => model.id)).toContain("codex/gpt-5.4")
     expect(body.data.map((model) => model.id)).toContain("codex/gpt-5.6-sol")
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  test("forwards Codex clients to the fixed Codex models endpoint", async () => {
+    providerConfigs = {
+      codex: {
+        apiKey: "codex-token",
+        authType: "oauth2",
+        baseUrl: "https://ignored.example/backend-api",
+        name: "codex",
+        type: "openai-responses",
+      },
+    }
+    state.codexAccessToken = "codex-access-token"
+    state.codexAccountId = "account-123"
+
+    const response = await createApp().request("/v1/models?client=codex", {
+      headers: {
+        accept: "*/*",
+        "user-agent": "codex-tui/0.144.1",
+      },
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://chatgpt.com/backend-api/codex/models?client=codex",
+    )
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers)
+    expect(headers.get("authorization")).toBe("Bearer codex-access-token")
+    expect(headers.get("chatgpt-account-id")).toBe("account-123")
+    expect(headers.get("accept")).toBe("*/*")
   })
 })

--- a/tests/provider-messages-web-search.test.ts
+++ b/tests/provider-messages-web-search.test.ts
@@ -58,9 +58,13 @@ const { providerMessageRoutes } = await import(
 )
 const { messageRoutes } = await import("../src/routes/messages/route")
 const { state } = await import("../src/lib/state")
+const { responsesUtilsDependencies } = await import(
+  "../src/routes/responses/utils"
+)
 
 const originalCodexAccessToken = state.codexAccessToken
 const originalCodexAccountId = state.codexAccountId
+const defaultResponsesUtilsDependencies = { ...responsesUtilsDependencies }
 
 const makeResponsesResult = (
   overrides: Partial<ResponsesResult> = {},
@@ -301,6 +305,11 @@ beforeEach(() => {
   state.codexAccountId = "codex-account"
   messageApiWebSearchModel = undefined
   findEndpointModel.mockClear()
+  responsesUtilsDependencies.getModelResponsesApiCompactThreshold = () =>
+    undefined
+  responsesUtilsDependencies.isContextManagementEnabledForMessages = () => true
+  responsesUtilsDependencies.isContextManagementEnabledForResponses = () =>
+    false
   fetchMock.mockClear()
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
     fetchMock as unknown as typeof fetch
@@ -310,11 +319,45 @@ afterEach(() => {
   ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
   state.codexAccessToken = originalCodexAccessToken
   state.codexAccountId = originalCodexAccountId
+  Object.assign(responsesUtilsDependencies, defaultResponsesUtilsDependencies)
   providerConfigs = {}
   messageApiWebSearchModel = undefined
 })
 
 describe("provider messages web_search", () => {
+  test("adds context management when provider Messages uses Responses API", async () => {
+    const app = createApp()
+    const response = await app.request("/search/v1/messages", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        max_tokens: 128,
+        messages: [{ role: "user", content: "hello" }],
+        model: "gpt-search",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("https://provider.example/v1/responses")
+
+    const upstreamBody = JSON.parse((init as RequestInit).body as string) as {
+      context_management?: unknown
+      model: string
+    }
+    expect(upstreamBody.model).toBe("gpt-search")
+    expect(upstreamBody.context_management).toEqual([
+      {
+        compact_threshold: 170000,
+        type: "compaction",
+      },
+    ])
+  })
+
   test("routes top-level Copilot messages web_search to provider/model", async () => {
     messageApiWebSearchModel = "search/gpt-search"
 

--- a/tests/provider-responses-context-management.test.ts
+++ b/tests/provider-responses-context-management.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+
+import type { ResolvedProviderConfig } from "../src/lib/config"
+import type { ResponsesResult } from "../src/services/copilot/create-responses"
+
+const actualConfigModule = await import("../src/lib/config")
+const actualTokenUsageModule = await import("../src/lib/token-usage")
+
+let providerConfig: ResolvedProviderConfig | null = null
+
+const noopTokenUsageRecorder = () => {}
+
+await mock.module("~/lib/config", () => ({
+  ...actualConfigModule,
+  getProviderConfig: () => providerConfig,
+  resolveMappedModel: (model: string) => model,
+}))
+
+await mock.module("~/lib/token-usage", () => ({
+  ...actualTokenUsageModule,
+  createProviderTokenUsageRecorder: () => noopTokenUsageRecorder,
+}))
+
+const { responsesRoutes } = await import("../src/routes/responses/route")
+const { responsesUtilsDependencies } = await import(
+  "../src/routes/responses/utils"
+)
+
+const defaultResponsesUtilsDependencies = { ...responsesUtilsDependencies }
+const originalFetch = globalThis.fetch
+
+const createResponsesResult = (model: string): ResponsesResult => ({
+  created_at: 0,
+  error: null,
+  id: "resp-test",
+  incomplete_details: null,
+  instructions: null,
+  metadata: null,
+  model,
+  object: "response",
+  output: [],
+  output_text: "",
+  parallel_tool_calls: false,
+  status: "completed",
+  temperature: null,
+  tool_choice: "auto",
+  tools: [],
+  top_p: null,
+  usage: null,
+})
+
+const parseJsonRequestBody = (body: unknown): unknown => {
+  if (typeof body !== "string") {
+    throw new Error("Expected JSON string request body")
+  }
+
+  return JSON.parse(body) as unknown
+}
+
+const fetchMock = mock((_url: string | URL | Request, init?: RequestInit) => {
+  const body = parseJsonRequestBody(init?.body) as { model: string }
+  return Promise.resolve(
+    new Response(JSON.stringify(createResponsesResult(body.model)), {
+      headers: {
+        "content-type": "application/json",
+      },
+    }),
+  )
+})
+
+const createApp = () => {
+  const app = new Hono()
+  app.route("/v1/responses", responsesRoutes)
+  return app
+}
+
+beforeEach(() => {
+  providerConfig = {
+    apiKey: "provider-key",
+    authType: "authorization",
+    baseUrl: "https://openai-responses.example",
+    models: {
+      "gpt-test": {},
+    },
+    name: "openai",
+    type: "openai-responses",
+  }
+
+  responsesUtilsDependencies.getModelResponsesApiCompactThreshold = () =>
+    undefined
+  responsesUtilsDependencies.isContextManagementEnabledForMessages = () => true
+  responsesUtilsDependencies.isContextManagementEnabledForResponses = () =>
+    false
+  fetchMock.mockClear()
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch =
+    fetchMock as unknown as typeof fetch
+})
+
+afterEach(() => {
+  ;(globalThis as unknown as { fetch: typeof fetch }).fetch = originalFetch
+  providerConfig = null
+  Object.assign(responsesUtilsDependencies, defaultResponsesUtilsDependencies)
+})
+
+describe("provider Responses context management", () => {
+  test("does not add context management or compact provider Responses input by default", async () => {
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify({
+        input: [
+          {
+            content: "older",
+            role: "user",
+          },
+          {
+            encrypted_content: "cipher",
+            id: "compaction-1",
+            type: "compaction",
+          },
+          {
+            content: "latest",
+            role: "user",
+          },
+        ],
+        model: "openai/gpt-test",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = parseJsonRequestBody((init as RequestInit).body) as {
+      context_management?: unknown
+      input: Array<unknown>
+    }
+
+    expect(body.context_management).toBeUndefined()
+    expect(body.input).toHaveLength(3)
+  })
+
+  test("adds context management and keeps only the latest compaction carrier when enabled", async () => {
+    responsesUtilsDependencies.isContextManagementEnabledForResponses = () =>
+      true
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify({
+        input: [
+          {
+            content: "older",
+            role: "user",
+          },
+          {
+            encrypted_content: "cipher",
+            id: "compaction-1",
+            type: "compaction",
+          },
+          {
+            content: "latest",
+            role: "user",
+          },
+        ],
+        model: "openai/gpt-test",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = parseJsonRequestBody((init as RequestInit).body) as {
+      context_management?: unknown
+      input: Array<Record<string, unknown>>
+    }
+
+    expect(body.context_management).toEqual([
+      {
+        compact_threshold: 160000,
+        type: "compaction",
+      },
+    ])
+    expect(body.input).toEqual([
+      {
+        encrypted_content: "cipher",
+        id: "compaction-1",
+        type: "compaction",
+      },
+      {
+        content: "latest",
+        role: "user",
+      },
+    ])
+  })
+})

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -306,9 +306,25 @@ describe("responses handler token usage", () => {
     )
 
     const app = createApp()
+    const latestInput = {
+      content: "Continue after the latest compaction.",
+      role: "user",
+    }
+    const compactionTrigger = {
+      type: "compaction_trigger",
+    }
     const response = await app.request("/v1/responses", {
       body: JSON.stringify({
         input: [
+          {
+            content: "old content before compaction",
+            role: "user",
+          },
+          {
+            encrypted_content: "cipher",
+            id: "compaction-1",
+            type: "compaction",
+          },
           {
             content: [
               {
@@ -320,9 +336,8 @@ describe("responses handler token usage", () => {
             role: "assistant",
             type: "message",
           },
-          {
-            type: "compaction_trigger",
-          },
+          latestInput,
+          compactionTrigger,
         ],
         model: "gpt-test",
       }),
@@ -335,6 +350,68 @@ describe("responses handler token usage", () => {
     expect(response.status).toBe(200)
     expect(createResponses).toHaveBeenCalledTimes(1)
     expect(createResponses.mock.calls[0][0].context_management).toBeUndefined()
+    expect(createResponses.mock.calls[0][0].input).toEqual([
+      {
+        encrypted_content: "cipher",
+        id: "compaction-1",
+        type: "compaction",
+      },
+      {
+        content: [
+          {
+            text: "Completed the review for the latest two commits.",
+            type: "output_text",
+          },
+        ],
+        phase: "final_answer",
+        role: "assistant",
+        type: "message",
+      },
+      latestInput,
+      compactionTrigger,
+    ])
+  })
+
+  test("does not compact input ending with compaction trigger when context management is disabled", async () => {
+    createResponses.mockImplementation((payload) =>
+      Promise.resolve(createResponsesResult(payload.model)),
+    )
+
+    const input = [
+      {
+        content: "old content before compaction",
+        role: "user",
+      },
+      {
+        encrypted_content: "cipher",
+        id: "compaction-1",
+        type: "compaction",
+      },
+      {
+        content: "Continue after the latest compaction.",
+        role: "user",
+      },
+      {
+        type: "compaction_trigger",
+      },
+    ]
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify({
+        input,
+        model: "gpt-test",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(1)
+    expect(createResponses.mock.calls[0][0].context_management).toBeUndefined()
+    expect(createResponses.mock.calls[0][0].input).toEqual(input)
   })
 
   test("preserves custom apply_patch tools for Copilot Responses", async () => {

--- a/tests/responses-handler.test.ts
+++ b/tests/responses-handler.test.ts
@@ -105,7 +105,9 @@ beforeEach(async () => {
   responsesHandlerDependencies.isResponsesApiWebSearchEnabled = () => true
   responsesUtilsDependencies.getModelResponsesApiCompactThreshold = () =>
     undefined
-  responsesUtilsDependencies.isResponsesApiContextManagementEnabled = () => true
+  responsesUtilsDependencies.isContextManagementEnabledForMessages = () => true
+  responsesUtilsDependencies.isContextManagementEnabledForResponses = () =>
+    false
   responsesUtilsDependencies.isResponsesApiWebSocketEnabled = () =>
     responsesApiWebSocketEnabled
   createResponses.mockReset()
@@ -228,6 +230,28 @@ describe("responses handler token usage", () => {
     expect(createResponses.mock.calls[0][1]?.transport).toBe("http")
   })
 
+  test("does not add context management to native Responses API by default", async () => {
+    createResponses.mockImplementation((payload) =>
+      Promise.resolve(createResponsesResult(payload.model)),
+    )
+
+    const app = createApp()
+    const response = await app.request("/v1/responses", {
+      body: JSON.stringify({
+        input: "hello",
+        model: "gpt-test",
+      }),
+      headers: {
+        "content-type": "application/json",
+      },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(createResponses).toHaveBeenCalledTimes(1)
+    expect(createResponses.mock.calls[0][0].context_management).toBeUndefined()
+  })
+
   test("uses model Responses API compact threshold before max token fallback", async () => {
     state.models = {
       object: "list",
@@ -246,6 +270,8 @@ describe("responses handler token usage", () => {
     responsesUtilsDependencies.getModelResponsesApiCompactThreshold = (
       model,
     ) => (model === "gpt-threshold-test" ? 272_000 * 0.8 : undefined)
+    responsesUtilsDependencies.isContextManagementEnabledForResponses = () =>
+      true
     createResponses.mockImplementation((payload) =>
       Promise.resolve(createResponsesResult(payload.model)),
     )
@@ -273,6 +299,8 @@ describe("responses handler token usage", () => {
   })
 
   test("does not add context management when input ends with compaction trigger", async () => {
+    responsesUtilsDependencies.isContextManagementEnabledForResponses = () =>
+      true
     createResponses.mockImplementation((payload) =>
       Promise.resolve(createResponsesResult(payload.model)),
     )


### PR DESCRIPTION
## 上游同步内容

同步 `caozhiyuan/dev` 的 20 个提交至 `v1.13.25`。

### 用户可见变化

- 改善 Responses API / WebSocket 兼容性与调试日志。
- 增加 Codex `/v1/models` 与 alpha search 入口。
- 更新 GPT-5.6 context compaction 阈值、token usage 归一化与 cache-write 计费展示支持。
- 移除无 Codex access token 时会产生误报的转发失败测试场景。

### 说明

`czy-all` 仅为上游同步 buffer，PR 用于将这些上游能力集成进本仓库 `dev`。