### PR TITLE
Sync upstream v1.14.14: desktop launch-at-login

### DIFF
--- a/desktop/build/installer.nsh
+++ b/desktop/build/installer.nsh
@@ -1,0 +1,7 @@
+!macro customUnInstall
+  # Preserve the stable Run entry during in-place updates.
+  ${ifNot} ${isUpdated}
+    DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Run" "${APP_ID}"
+    DeleteRegValue HKCU "Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" "${APP_ID}"
+  ${endIf}
+!macroend

--- a/desktop/electron/ipc-handlers.ts
+++ b/desktop/electron/ipc-handlers.ts
@@ -29,6 +29,7 @@ import {
   isRunning,
 } from './server-manager'
 import { readSettings, writeSettings } from './settings-store'
+import { runSettingsTransaction } from './settings-transaction'
 import type {
   DesktopAuthMode,
   DesktopProxySettings,
@@ -51,6 +52,10 @@ interface IpcHandlersOptions {
     settings: DesktopSettings,
   ) => DesktopProxySettings
   onSettingsChange?: (
+    settings: DesktopSettings,
+    prevSettings: DesktopSettings,
+  ) => void | Promise<void>
+  onBeforeSettingsSave?: (
     settings: DesktopSettings,
     prevSettings: DesktopSettings,
   ) => void | Promise<void>
@@ -291,8 +296,11 @@ export function registerIpcHandlers(
   ipcMain.handle('settings:get', async () => readSettings())
   ipcMain.handle('settings:save', async (_event, settings: DesktopSettings) => {
     const prev = await readSettings()
-    await writeSettings(settings)
-    // Notify the main process after settings are saved so tray state and labels stay in sync.
+    await runSettingsTransaction(
+      () => options.onBeforeSettingsSave?.(settings, prev),
+      () => writeSettings(settings),
+      () => options.onBeforeSettingsSave?.(prev, settings),
+    )
     if (options.onSettingsChange) {
       await options.onSettingsChange(settings, prev)
     }

--- a/desktop/electron/login-item.ts
+++ b/desktop/electron/login-item.ts
@@ -1,0 +1,177 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import type { DesktopSettings } from '../src/types/ipc'
+
+export const LOGIN_ITEM_ARG = '--launch-at-login'
+const WINDOWS_LOGIN_ITEM_NAME = 'com.copilot-api.desktop'
+
+interface LoginItemController {
+  readonly isPackaged: boolean
+  setLoginItemSettings(settings: Electron.Settings): void
+  getLoginItemSettings(): Pick<
+    Electron.LoginItemSettings,
+    'openAtLogin' | 'wasOpenedAtLogin' | 'launchItems'
+  >
+}
+
+interface LoginItemRuntime {
+  platform: NodeJS.Platform
+  execPath: string
+  argv: readonly string[]
+  appImagePath?: string
+  configHome?: string
+}
+
+function getCurrentRuntime(): LoginItemRuntime {
+  const configHome = process.env.XDG_CONFIG_HOME
+
+  return {
+    platform: process.platform,
+    execPath: process.execPath,
+    argv: process.argv,
+    appImagePath: process.env.APPIMAGE,
+    configHome:
+      configHome && path.isAbsolute(configHome) ?
+        configHome
+      : path.join(os.homedir(), '.config'),
+  }
+}
+
+function supportsLaunchAtLogin(platform: NodeJS.Platform): boolean {
+  return platform === 'win32' || platform === 'darwin' || platform === 'linux'
+}
+
+function getLinuxAutostartPath(runtime: LoginItemRuntime): string {
+  const configHome = runtime.configHome ?? path.join(os.homedir(), '.config')
+  return path.join(configHome, 'autostart', 'copilot-api.desktop')
+}
+
+function quoteDesktopExecArg(value: string): string {
+  // GLib rejects percent signs in executable paths even when escaped as %%.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f%]/.test(value)) {
+    throw new Error(
+      'Linux launch-at-login path contains unsupported characters',
+    )
+  }
+
+  return `"${value
+    .replaceAll('\\', '\\\\\\\\')
+    .replace(/["`$]/g, (character) => `\\\\${character}`)}"`
+}
+
+export async function applyLaunchAtLogin(
+  controller: LoginItemController,
+  settings: Pick<DesktopSettings, 'launchAtLogin' | 'minimizeToTray'>,
+  runtime: LoginItemRuntime = getCurrentRuntime(),
+): Promise<void> {
+  if (!controller.isPackaged || !supportsLaunchAtLogin(runtime.platform)) {
+    return
+  }
+
+  if (runtime.platform === 'linux') {
+    const autostartPath = getLinuxAutostartPath(runtime)
+
+    if (!settings.launchAtLogin) {
+      await fs.rm(autostartPath, { force: true })
+      return
+    }
+
+    const executable = runtime.appImagePath || runtime.execPath
+    const entry = `[Desktop Entry]
+Type=Application
+Name=Copilot API
+Exec=${quoteDesktopExecArg(executable)} ${LOGIN_ITEM_ARG}
+Terminal=false
+`
+
+    await fs.mkdir(path.dirname(autostartPath), { recursive: true })
+    await fs.writeFile(autostartPath, entry, 'utf8')
+    return
+  }
+
+  if (runtime.platform === 'win32') {
+    controller.setLoginItemSettings({
+      openAtLogin: settings.launchAtLogin,
+      path: runtime.execPath,
+      args: [LOGIN_ITEM_ARG],
+      name: WINDOWS_LOGIN_ITEM_NAME,
+    })
+    return
+  }
+
+  controller.setLoginItemSettings({
+    openAtLogin: settings.launchAtLogin,
+    openAsHidden: settings.minimizeToTray,
+  })
+}
+
+export async function initializeLaunchAtLogin(
+  controller: LoginItemController,
+  runtime: LoginItemRuntime = getCurrentRuntime(),
+): Promise<boolean> {
+  if (!controller.isPackaged || !supportsLaunchAtLogin(runtime.platform)) {
+    return false
+  }
+
+  if (runtime.platform === 'linux') {
+    try {
+      const entry = await fs.readFile(getLinuxAutostartPath(runtime), 'utf8')
+      return !/^\s*(?:Hidden\s*=\s*true|X-GNOME-Autostart-enabled\s*=\s*false)\s*$/im.test(
+        entry,
+      )
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false
+      throw error
+    }
+  }
+
+  const current = controller.getLoginItemSettings()
+  if (runtime.platform === 'win32') {
+    const item =
+      current.launchItems.find(
+        ({ name, scope }) =>
+          name === WINDOWS_LOGIN_ITEM_NAME && scope === 'user',
+      )
+      ?? current.launchItems.find(
+        ({ name }) => name === WINDOWS_LOGIN_ITEM_NAME,
+      )
+
+    if (!item) return false
+
+    if (
+      item.path !== runtime.execPath
+      || item.args.length !== 1
+      || item.args[0] !== LOGIN_ITEM_ARG
+    ) {
+      controller.setLoginItemSettings({
+        openAtLogin: true,
+        path: runtime.execPath,
+        args: [LOGIN_ITEM_ARG],
+        enabled: item.enabled,
+        name: WINDOWS_LOGIN_ITEM_NAME,
+      })
+    }
+
+    return item.enabled
+  }
+
+  return current.openAtLogin
+}
+
+export function wasLaunchedAtLogin(
+  controller: LoginItemController,
+  runtime: LoginItemRuntime = getCurrentRuntime(),
+): boolean {
+  if (!supportsLaunchAtLogin(runtime.platform)) {
+    return false
+  }
+
+  if (runtime.platform === 'win32' || runtime.platform === 'linux') {
+    return runtime.argv.includes(LOGIN_ITEM_ARG)
+  }
+
+  return controller.getLoginItemSettings().wasOpenedAtLogin
+}

--- a/desktop/electron/main.ts
+++ b/desktop/electron/main.ts
@@ -23,7 +23,17 @@ import {
   hasNoProxyServerSwitch,
 } from './electron-proxy-config'
 import { tMain } from './i18n'
-import { readSettings, readSettingsSync } from './settings-store'
+import {
+  applyLaunchAtLogin,
+  initializeLaunchAtLogin,
+  LOGIN_ITEM_ARG,
+  wasLaunchedAtLogin,
+} from './login-item'
+import {
+  readSettings,
+  readSettingsSync,
+  setLaunchAtLoginFallback,
+} from './settings-store'
 
 const CLI_ENV_FLAGS = {
   '--api-home': 'COPILOT_API_HOME',
@@ -141,6 +151,7 @@ function getRuntimeDependencies(): Promise<RuntimeDependencies> {
 
 let tray: Tray | null = null
 let mainWindow: BrowserWindow | null = null
+let showWindowWhenReady = false
 // Track exits triggered by menu or system actions instead of the close button
 let isQuitting = false
 
@@ -172,6 +183,9 @@ function showWindow(win: BrowserWindow): void {
   // Restore the Dock icon before showing the window on macOS.
   if (process.platform === 'darwin') {
     void app.dock?.show()
+  }
+  if (win.isMinimized()) {
+    win.restore()
   }
   win.show()
   win.focus()
@@ -235,7 +249,7 @@ function destroyTray(): void {
   }
 }
 
-function createWindow(): BrowserWindow {
+function createWindow(startHidden = false): BrowserWindow {
   const win = new BrowserWindow({
     width: 1000,
     height: 650,
@@ -255,9 +269,14 @@ function createWindow(): BrowserWindow {
   win.removeMenu()
 
   mainWindow = win
-  win.maximize()
+  if (startHidden) win.once('show', () => win.maximize())
+  else win.maximize()
 
-  win.once('ready-to-show', () => win.show())
+  win.once('ready-to-show', () => {
+    if (!startHidden) {
+      win.show()
+    }
+  })
 
   win.on('closed', () => {
     if (mainWindow === win) {
@@ -308,17 +327,33 @@ function createWindow(): BrowserWindow {
   return win
 }
 
-void app.whenReady().then(async () => {
+async function initializeApplication(): Promise<void> {
+  try {
+    setLaunchAtLoginFallback(await initializeLaunchAtLogin(app))
+  } catch (error) {
+    console.error('Failed to read launch-at-login setting:', error)
+  }
+
   const { registerIpcHandlers, readSettings, onStatusChange, onLog } =
     await getRuntimeDependencies()
   const settings = await readSettings()
   await applyElectronProxy(getEffectiveProxySettings(settings))
 
-  const win = createWindow()
+  const launchedAtLogin = wasLaunchedAtLogin(app)
+
+  const startHidden =
+    settings.minimizeToTray && launchedAtLogin && !showWindowWhenReady
+  showWindowWhenReady = false
+  const win = createWindow(startHidden)
 
   registerIpcHandlers(win, {
     getEffectiveProxySettings,
     onQuit: quitApplication,
+    onBeforeSettingsSave: async (settings, prevSettings) => {
+      if (settings.launchAtLogin !== prevSettings.launchAtLogin) {
+        await applyLaunchAtLogin(app, settings)
+      }
+    },
     onSettingsChange: async (settings, prevSettings) => {
       await applyElectronProxy(getEffectiveProxySettings(settings))
 
@@ -351,6 +386,9 @@ void app.whenReady().then(async () => {
   // Only create the tray when minimize-to-tray is enabled.
   if (settings.minimizeToTray) {
     await createTray(win)
+    if (startHidden && process.platform === 'darwin') {
+      app.dock?.hide()
+    }
   }
 
   onStatusChange((status) => {
@@ -372,15 +410,31 @@ void app.whenReady().then(async () => {
       showWindow(mainWindow)
     }
   })
-})
+}
 
-app.on('before-quit', async () => {
-  isQuitting = true
-  const { stopServer } = await getRuntimeDependencies()
-  await stopServer()
-})
+if (app.requestSingleInstanceLock()) {
+  app.on('second-instance', (_event, argv) => {
+    if (argv.includes(LOGIN_ITEM_ARG)) return
 
-// This will not fire in the macOS tray flow because the close event is intercepted.
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') app.quit()
-})
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      showWindow(mainWindow)
+    } else {
+      showWindowWhenReady = true
+    }
+  })
+
+  void app.whenReady().then(initializeApplication)
+
+  app.on('before-quit', async () => {
+    isQuitting = true
+    const { stopServer } = await getRuntimeDependencies()
+    await stopServer()
+  })
+
+  // This will not fire in the macOS tray flow because the close event is intercepted.
+  app.on('window-all-closed', () => {
+    if (process.platform !== 'darwin') app.quit()
+  })
+} else {
+  app.quit()
+}

--- a/desktop/electron/settings-store.ts
+++ b/desktop/electron/settings-store.ts
@@ -18,6 +18,7 @@ const DEFAULT_SETTINGS: DesktopSettings = {
   oauthApp: 'default',
   enterpriseUrl: '',
   lastPort: 4141,
+  launchAtLogin: false,
   minimizeToTray: false,
   accountType: 'individual',
   verbose: false,
@@ -30,6 +31,12 @@ const DEFAULT_SETTINGS: DesktopSettings = {
     https_proxy: 'http://127.0.0.1:8888',
     no_proxy: 'localhost,127.0.0.1',
   },
+}
+
+let launchAtLoginFallback = DEFAULT_SETTINGS.launchAtLogin
+
+export function setLaunchAtLoginFallback(enabled: boolean): void {
+  launchAtLoginFallback = enabled
 }
 
 function isDesktopProxyMode(
@@ -81,6 +88,10 @@ export function normalizeSettings(
       typeof settings?.lastPort === 'number' ?
         settings.lastPort
       : DEFAULT_SETTINGS.lastPort,
+    launchAtLogin:
+      typeof settings?.launchAtLogin === 'boolean' ?
+        settings.launchAtLogin
+      : launchAtLoginFallback,
     minimizeToTray:
       typeof settings?.minimizeToTray === 'boolean' ?
         settings.minimizeToTray
@@ -125,7 +136,7 @@ export function readSettingsSync(): DesktopSettings {
     const raw = fsSync.readFileSync(SETTINGS_PATH, 'utf8')
     return normalizeSettings(JSON.parse(raw) as Partial<DesktopSettings>)
   } catch {
-    return { ...DEFAULT_SETTINGS, proxy: { ...DEFAULT_SETTINGS.proxy } }
+    return normalizeSettings(null)
   }
 }
 
@@ -134,7 +145,7 @@ export async function readSettings(): Promise<DesktopSettings> {
     const raw = await fs.readFile(SETTINGS_PATH, 'utf8')
     return normalizeSettings(JSON.parse(raw) as Partial<DesktopSettings>)
   } catch {
-    return { ...DEFAULT_SETTINGS, proxy: { ...DEFAULT_SETTINGS.proxy } }
+    return normalizeSettings(null)
   }
 }
 

--- a/desktop/electron/settings-transaction.ts
+++ b/desktop/electron/settings-transaction.ts
@@ -1,0 +1,19 @@
+type SettingsTask = () => void | Promise<void>
+
+export async function runSettingsTransaction(
+  apply: SettingsTask,
+  persist: SettingsTask,
+  rollback: SettingsTask,
+): Promise<void> {
+  try {
+    await apply()
+    await persist()
+  } catch (error) {
+    try {
+      await rollback()
+    } catch (rollbackError) {
+      console.error('Failed to roll back desktop settings:', rollbackError)
+    }
+    throw error
+  }
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "1.14.13",
+  "version": "1.14.14",
   "description": "Copilot API Desktop App",
   "author": "jeffreycao",
   "desktopName": "copilot-api.desktop",

--- a/desktop/src/components/SettingsModal.tsx
+++ b/desktop/src/components/SettingsModal.tsx
@@ -206,6 +206,7 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
     oauthApp: 'default',
     enterpriseUrl: '',
     lastPort: 4141,
+    launchAtLogin: false,
     minimizeToTray: false,
     accountType: 'individual',
     verbose: false,
@@ -255,6 +256,16 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
       }
 
       onClose()
+    } catch (error) {
+      const savedSettings = await window.electronAPI
+        .getSettings()
+        .catch(() => initialSettings)
+      if (savedSettings) {
+        setSettings(savedSettings)
+        setLangPref(savedSettings.language)
+        setThemePref(savedSettings.theme)
+      }
+      window.alert(error instanceof Error ? error.message : String(error))
     } finally {
       setSaving(false)
     }
@@ -416,6 +427,22 @@ export default function SettingsModal({ onClose }: SettingsModalProps) {
                     ))}
                   </div>
                 </div>
+
+                {(window.electronAPI.platform === 'win32'
+                  || window.electronAPI.platform === 'darwin'
+                  || window.electronAPI.platform === 'linux') && (
+                  <SettingRow
+                    label={t('settings.launchAtLogin')}
+                    description={t('settings.launchAtLoginDesc')}
+                  >
+                    <Toggle
+                      checked={settings.launchAtLogin}
+                      onChange={(v) =>
+                        setSettings((s) => ({ ...s, launchAtLogin: v }))
+                      }
+                    />
+                  </SettingRow>
+                )}
 
                 <SettingRow
                   label={t('settings.minimizeToTray')}

--- a/desktop/src/locales/en.ts
+++ b/desktop/src/locales/en.ts
@@ -147,6 +147,9 @@ const en: Locale = {
     restartAppPrompt:
       'Saved. Restart the app for OAuth App, API Home, and Enterprise URL changes to take effect.',
     sectionGeneral: 'General',
+    launchAtLogin: 'Launch at login',
+    launchAtLoginDesc:
+      'Launch Copilot API when you sign in; starts hidden when Minimize to tray is enabled',
     minimizeToTray: 'Minimize to tray',
     minimizeToTrayDesc: "Hide to system tray when closing, don't quit",
     sectionNetwork: 'Network',

--- a/desktop/src/locales/index.ts
+++ b/desktop/src/locales/index.ts
@@ -141,6 +141,8 @@ export interface Locale {
     restartAppNote: string
     restartAppPrompt: string
     sectionGeneral: string
+    launchAtLogin: string
+    launchAtLoginDesc: string
     minimizeToTray: string
     minimizeToTrayDesc: string
     sectionNetwork: string

--- a/desktop/src/locales/zh.ts
+++ b/desktop/src/locales/zh.ts
@@ -142,6 +142,9 @@ const zh: Locale = {
     restartAppPrompt:
       '设置已保存。OAuth App、API Home 和 Enterprise URL 需重启应用后才能生效。',
     sectionGeneral: '通用',
+    launchAtLogin: '登录时启动',
+    launchAtLoginDesc:
+      '登录操作系统时启动 Copilot API；启用“最小化到托盘”后将静默启动',
     minimizeToTray: '最小化到托盘',
     minimizeToTrayDesc: '关闭窗口时隐藏到系统托盘，不退出程序',
     sectionNetwork: '网络',

--- a/desktop/src/types/ipc.ts
+++ b/desktop/src/types/ipc.ts
@@ -170,6 +170,7 @@ export interface DesktopSettings {
   oauthApp: 'default' | 'opencode'
   enterpriseUrl: string
   lastPort: number
+  launchAtLogin: boolean
   minimizeToTray: boolean
   accountType: 'individual' | 'business' | 'enterprise'
   verbose: boolean

--- a/desktop/tests/desktop-proxy-config.test.ts
+++ b/desktop/tests/desktop-proxy-config.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   normalizeProxySettings,
   normalizeSettings,
+  setLaunchAtLoginFallback,
 } from '../electron/settings-store'
 import type { DesktopProxySettings } from '../src/types/ipc'
 
@@ -169,6 +170,7 @@ describe('desktop proxy config', () => {
       oauthApp: 'default',
       enterpriseUrl: '',
       lastPort: 4141,
+      launchAtLogin: false,
       minimizeToTray: false,
       accountType: 'individual',
       verbose: false,
@@ -189,6 +191,7 @@ describe('desktop proxy config', () => {
         oauthApp: 'opencode',
         enterpriseUrl: 'ghe.example.com',
         lastPort: 5151,
+        launchAtLogin: true,
         minimizeToTray: true,
         accountType: 'enterprise',
         verbose: true,
@@ -201,6 +204,7 @@ describe('desktop proxy config', () => {
       oauthApp: 'opencode',
       enterpriseUrl: 'ghe.example.com',
       lastPort: 5151,
+      launchAtLogin: true,
       minimizeToTray: true,
       accountType: 'enterprise',
       verbose: true,
@@ -222,5 +226,17 @@ describe('desktop proxy config', () => {
     ).toBe('auto')
     expect(normalizeSettings({}).theme).toBe('auto')
     expect(normalizeSettings(null).theme).toBe('auto')
+  })
+
+  test('preserves the OS login state when migrating old settings', () => {
+    setLaunchAtLoginFallback(true)
+    try {
+      expect(normalizeSettings({}).launchAtLogin).toBe(true)
+      expect(normalizeSettings({ launchAtLogin: false }).launchAtLogin).toBe(
+        false,
+      )
+    } finally {
+      setLaunchAtLoginFallback(false)
+    }
   })
 })

--- a/desktop/tests/login-item.test.ts
+++ b/desktop/tests/login-item.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  applyLaunchAtLogin,
+  initializeLaunchAtLogin,
+  LOGIN_ITEM_ARG,
+  wasLaunchedAtLogin,
+} from '../electron/login-item'
+
+function createController(
+  options: {
+    isPackaged?: boolean
+    launchItems?: Electron.LaunchItems[]
+    openAtLogin?: boolean
+    wasOpenedAtLogin?: boolean
+  } = {},
+) {
+  const calls: Electron.Settings[] = []
+  return {
+    calls,
+    isPackaged: options.isPackaged ?? true,
+    setLoginItemSettings: (settings: Electron.Settings) => {
+      calls.push(settings)
+    },
+    getLoginItemSettings: () => ({
+      launchItems: options.launchItems ?? [],
+      openAtLogin: options.openAtLogin ?? false,
+      wasOpenedAtLogin: options.wasOpenedAtLogin ?? false,
+    }),
+  }
+}
+
+describe('desktop login item', () => {
+  test('configures the packaged Windows login item with a launch marker', async () => {
+    const controller = createController()
+    const runtime = {
+      platform: 'win32' as const,
+      execPath: 'C:\\Program Files\\Copilot API\\Copilot API.exe',
+      argv: [],
+    }
+
+    await applyLaunchAtLogin(
+      controller,
+      { launchAtLogin: true, minimizeToTray: true },
+      runtime,
+    )
+    await applyLaunchAtLogin(
+      controller,
+      { launchAtLogin: false, minimizeToTray: false },
+      runtime,
+    )
+
+    expect(controller.calls).toEqual([
+      {
+        openAtLogin: true,
+        path: runtime.execPath,
+        args: [LOGIN_ITEM_ARG],
+        name: 'com.copilot-api.desktop',
+      },
+      {
+        openAtLogin: false,
+        path: runtime.execPath,
+        args: [LOGIN_ITEM_ARG],
+        name: 'com.copilot-api.desktop',
+      },
+    ])
+  })
+
+  test('preserves a disabled Windows login item while refreshing its path', async () => {
+    const runtime = {
+      platform: 'win32' as const,
+      execPath: 'C:\\Program Files\\Copilot API\\Copilot API.exe',
+      argv: [],
+    }
+    const controller = createController({
+      launchItems: [
+        {
+          name: 'com.copilot-api.desktop',
+          path: 'C:\\Old\\Copilot API.exe',
+          args: [],
+          scope: 'user',
+          enabled: false,
+        },
+      ],
+    })
+
+    expect(await initializeLaunchAtLogin(controller, runtime)).toBe(false)
+    expect(controller.calls).toEqual([
+      {
+        openAtLogin: true,
+        path: runtime.execPath,
+        args: [LOGIN_ITEM_ARG],
+        enabled: false,
+        name: 'com.copilot-api.desktop',
+      },
+    ])
+
+    const current = createController({
+      launchItems: [
+        {
+          name: 'com.copilot-api.desktop',
+          path: runtime.execPath,
+          args: [LOGIN_ITEM_ARG],
+          scope: 'user',
+          enabled: true,
+        },
+      ],
+    })
+    expect(await initializeLaunchAtLogin(current, runtime)).toBe(true)
+    expect(current.calls).toEqual([])
+    expect(await initializeLaunchAtLogin(createController(), runtime)).toBe(
+      false,
+    )
+  })
+
+  test('configures macOS to open hidden with minimize-to-tray', async () => {
+    const controller = createController()
+    const runtime = {
+      platform: 'darwin' as const,
+      execPath: '/Applications/Copilot API.app/Contents/MacOS/Copilot API',
+      argv: [],
+    }
+
+    await applyLaunchAtLogin(
+      controller,
+      { launchAtLogin: true, minimizeToTray: true },
+      runtime,
+    )
+
+    expect(controller.calls).toEqual([
+      { openAtLogin: true, openAsHidden: true },
+    ])
+
+    expect(
+      await initializeLaunchAtLogin(
+        createController({ openAtLogin: true }),
+        runtime,
+      ),
+    ).toBe(true)
+  })
+
+  test('manages the packaged Linux XDG autostart entry', async () => {
+    const configHome = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'copilot-api-login-'),
+    )
+    const autostartPath = path.join(
+      configHome,
+      'autostart',
+      'copilot-api.desktop',
+    )
+    const runtime = {
+      platform: 'linux' as const,
+      execPath: '/tmp/.mount-copilot/copilot-api',
+      configHome,
+      argv: [],
+    }
+    const controller = createController()
+    const enabled = { launchAtLogin: true, minimizeToTray: false }
+
+    try {
+      await applyLaunchAtLogin(controller, enabled, {
+        ...runtime,
+        appImagePath: '/home/jay/Copilot API.AppImage',
+      })
+
+      expect(await fs.readFile(autostartPath, 'utf8')).toBe(`[Desktop Entry]
+Type=Application
+Name=Copilot API
+Exec="/home/jay/Copilot API.AppImage" ${LOGIN_ITEM_ARG}
+Terminal=false
+`)
+      expect(await initializeLaunchAtLogin(controller, runtime)).toBe(true)
+
+      await fs.appendFile(autostartPath, 'Hidden=true\n')
+      expect(await initializeLaunchAtLogin(controller, runtime)).toBe(false)
+      expect(controller.calls).toEqual([])
+
+      await applyLaunchAtLogin(controller, enabled, {
+        ...runtime,
+        appImagePath: '',
+      })
+      expect(await fs.readFile(autostartPath, 'utf8')).toContain(
+        'Exec="/tmp/.mount-copilot/copilot-api"',
+      )
+
+      await applyLaunchAtLogin(controller, enabled, {
+        ...runtime,
+        appImagePath: '/home/jay/Copilot =`$"\\ AppImage',
+      })
+
+      expect(await fs.readFile(autostartPath, 'utf8')).toContain(
+        'Exec="/home/jay/Copilot =\\\\`\\\\$\\\\"\\\\\\\\ AppImage" --launch-at-login',
+      )
+
+      for (const appImagePath of [
+        '/home/jay/Copilot 100%.AppImage',
+        '/tmp/a\tb',
+      ]) {
+        await expect(
+          applyLaunchAtLogin(controller, enabled, { ...runtime, appImagePath }),
+        ).rejects.toThrow('contains unsupported characters')
+      }
+
+      await applyLaunchAtLogin(
+        controller,
+        { launchAtLogin: false, minimizeToTray: false },
+        runtime,
+      )
+      expect(await Bun.file(autostartPath).exists()).toBe(false)
+      expect(await initializeLaunchAtLogin(controller, runtime)).toBe(false)
+    } finally {
+      await fs.rm(configHome, { recursive: true, force: true })
+    }
+  })
+
+  test('skips unsupported or unpackaged apps', async () => {
+    const settings = { launchAtLogin: true, minimizeToTray: false }
+    const unsupported = createController()
+    await applyLaunchAtLogin(unsupported, settings, {
+      platform: 'freebsd',
+      execPath: '/opt/copilot-api',
+      argv: [],
+    })
+
+    const unpackaged = createController({ isPackaged: false })
+    await applyLaunchAtLogin(unpackaged, settings)
+
+    expect(unsupported.calls).toEqual([])
+    expect(unpackaged.calls).toEqual([])
+    expect(
+      await initializeLaunchAtLogin(unsupported, {
+        platform: 'freebsd',
+        execPath: '/opt/copilot-api',
+        argv: [],
+      }),
+    ).toBe(false)
+    expect(await initializeLaunchAtLogin(unpackaged)).toBe(false)
+  })
+
+  test('detects login launches by platform', () => {
+    const launched = (platform: NodeJS.Platform, argv: string[] = []) =>
+      wasLaunchedAtLogin(createController(), {
+        platform,
+        execPath: 'copilot-api',
+        argv,
+      })
+
+    const mac = createController({ wasOpenedAtLogin: true })
+    expect(
+      wasLaunchedAtLogin(mac, {
+        platform: 'darwin',
+        execPath: 'copilot-api',
+        argv: [],
+      }),
+    ).toBe(true)
+    expect(launched('win32', [LOGIN_ITEM_ARG])).toBe(true)
+    expect(launched('win32')).toBe(false)
+    expect(launched('linux', [LOGIN_ITEM_ARG])).toBe(true)
+    expect(launched('freebsd')).toBe(false)
+  })
+})

--- a/desktop/tests/settings-store.test.ts
+++ b/desktop/tests/settings-store.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'bun:test'
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+test('uses the OS fallback when the settings file does not exist', async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), 'copilot-api-settings-'))
+  const moduleUrl = pathToFileURL(
+    path.join(import.meta.dir, '../electron/settings-store.ts'),
+  ).href
+  const script = `
+    import { readSettings, readSettingsSync, setLaunchAtLoginFallback } from ${JSON.stringify(moduleUrl)}
+    setLaunchAtLoginFallback(true)
+    process.stdout.write(JSON.stringify([
+      readSettingsSync().launchAtLogin,
+      (await readSettings()).launchAtLogin,
+    ]))
+  `
+
+  try {
+    const child = Bun.spawn([process.execPath, '-e', script], {
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      stderr: 'pipe',
+      stdout: 'pipe',
+    })
+    const [exitCode, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ])
+
+    expect(stderr).toBe('')
+    expect(exitCode).toBe(0)
+    expect(stdout).toBe('[true,true]')
+  } finally {
+    await fs.rm(home, { force: true, recursive: true })
+  }
+})

--- a/desktop/tests/settings-transaction.test.ts
+++ b/desktop/tests/settings-transaction.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, spyOn, test } from 'bun:test'
+
+import { runSettingsTransaction } from '../electron/settings-transaction'
+
+describe('desktop settings transaction', () => {
+  test('applies before persistence and rolls back persistence failures', async () => {
+    const events: string[] = []
+
+    await runSettingsTransaction(
+      () => events.push('apply'),
+      () => events.push('persist'),
+      () => events.push('rollback'),
+    )
+    expect(events).toEqual(['apply', 'persist'])
+
+    events.length = 0
+    const error = new Error('write failed')
+    await expect(
+      runSettingsTransaction(
+        () => events.push('apply'),
+        () => {
+          events.push('persist')
+          throw error
+        },
+        () => events.push('rollback'),
+      ),
+    ).rejects.toBe(error)
+    expect(events).toEqual(['apply', 'persist', 'rollback'])
+  })
+
+  test('preserves the original error when rollback also fails', async () => {
+    const error = new Error('write failed')
+    const log = spyOn(console, 'error').mockImplementation(() => {})
+
+    try {
+      await expect(
+        runSettingsTransaction(
+          () => {},
+          () => {
+            throw error
+          },
+          () => {
+            throw new Error('rollback failed')
+          },
+        ),
+      ).rejects.toBe(error)
+      expect(log).toHaveBeenCalledTimes(1)
+    } finally {
+      log.mockRestore()
+    }
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "1.14.13",
+  "version": "1.14.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "1.14.13",
+      "version": "1.14.14",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "1.14.13",
+  "version": "1.14.14",
   "description": "GitHub Copilot, OpenAI Codex, and third-party AI provider gateway with OpenAI and Anthropic API compatibility.",
   "keywords": [
     "github-copilot",


### PR DESCRIPTION
同步 caozhiyuan/dev 的 2 个提交：

- 1585723 feat(desktop): add launch-at-login option
  - 桌面端支持 Windows、macOS、Linux 开机启动设置。
  - 增加设置事务、安装卸载处理、IPC、界面文案与测试。
- 4959ba0 chore: bump version to 1.14.14
  - 更新根项目、桌面端及 package-lock 版本号。

Dry run：dev <- caozhiyuan/dev 预测无冲突。
本 PR 未包含本地修复提交。