### PR TITLE
sync: caozhiyuan/dev v2.1.7-v2.1.8 (prompt cache key + empty thinking)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "Copilot API Desktop App",
   "author": "jeffreycao",
   "desktopName": "copilot-api.desktop",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-api-desktop",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "Copilot API Desktop App",
   "author": "jeffreycao",
   "desktopName": "copilot-api.desktop",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jeffreycao/copilot-api",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jeffreycao/copilot-api",
-      "version": "2.1.7",
+      "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "2.1.7",
+  "version": "2.1.8",
   "description": "GitHub Copilot, OpenAI Codex, OpenCode Go, and third-party AI provider gateway with OpenAI and Anthropic API compatibility.",
   "keywords": [
     "github-copilot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@jeffreycao/copilot-api",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "GitHub Copilot, OpenAI Codex, OpenCode Go, and third-party AI provider gateway with OpenAI and Anthropic API compatibility.",
   "keywords": [
     "github-copilot",

--- a/src/lib/types/chat-completions.ts
+++ b/src/lib/types/chat-completions.ts
@@ -128,6 +128,7 @@ export interface ChatCompletionsPayload {
   } | null
   thinking_budget?: number
   reasoning_effort?: string
+  prompt_cache_key?: string | null
   top_k?: number | null
   parallel_tool_calls?: boolean | null
 }

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -30,6 +30,7 @@ import {
   type AnthropicUserMessage,
 } from "~/lib/types/anthropic"
 import { mapOpenAIStopReasonToAnthropic } from "./utils"
+import { parseUserIdMetadata } from "~/lib/utils"
 
 // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we need add a default thinking text
 export const THINKING_TEXT = "Thinking..."
@@ -77,7 +78,12 @@ export function translateToOpenAI(
   const model = state.models?.data.find((m) => m.id === modelId)
   const thinkingBudget = getThinkingBudget(payload, model)
   const reasoningEffort = getReasoningEffort(payload, options)
-  const promptCacheKey = requestContext.getStore()?.sessionAffinity?.trim()
+  const { sessionId: metadataPromptCacheKey } = parseUserIdMetadata(
+    payload.metadata?.user_id,
+  )
+  const requestStore = requestContext.getStore()
+  const sessionAffinity = requestStore?.sessionAffinity?.trim() || null
+  const promptCacheKey = metadataPromptCacheKey ?? sessionAffinity
   const capabilities = {
     supportPdf: options.supportPdf ?? false,
     toolContentSupportType:

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -376,10 +376,14 @@ function handleAssistantMessage(
   )
 
   if (modelId.startsWith("claude")) {
+    // Keep signature-only blocks (empty thinking text): the signature, not the
+    // summary text, carries reasoning continuity and is forwarded upstream as
+    // reasoning_opaque. Dropping empty-text blocks would silently lose those
+    // signatures. The THINKING_TEXT placeholder is still excluded: it is a
+    // synthetic value emitted by older versions, never real model output.
     thinkingBlocks = thinkingBlocks.filter(
       (b) =>
-        b.thinking
-        && b.thinking !== THINKING_TEXT
+        b.thinking !== THINKING_TEXT
         && b.signature
         // gpt signature has @ in it, so filter those out for claude models
         && !b.signature.includes("@"),
@@ -658,7 +662,7 @@ function getAnthropicThinkBlocks(
     return [
       {
         type: "thinking",
-        thinking: THINKING_TEXT, // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
+        thinking: "",
         signature: reasoningOpaque,
       },
     ]

--- a/src/routes/messages/non-stream-translation.ts
+++ b/src/routes/messages/non-stream-translation.ts
@@ -1,6 +1,7 @@
 import type { ToolContentSupportType } from "~/lib/config"
 import type { Model } from "~/lib/types/models"
 
+import { requestContext } from "~/lib/request-context"
 import { state } from "~/lib/state"
 import {
   type ChatCompletionResponse,
@@ -76,6 +77,7 @@ export function translateToOpenAI(
   const model = state.models?.data.find((m) => m.id === modelId)
   const thinkingBudget = getThinkingBudget(payload, model)
   const reasoningEffort = getReasoningEffort(payload, options)
+  const promptCacheKey = requestContext.getStore()?.sessionAffinity?.trim()
   const capabilities = {
     supportPdf: options.supportPdf ?? false,
     toolContentSupportType:
@@ -98,6 +100,7 @@ export function translateToOpenAI(
     tool_choice: translateAnthropicToolChoiceToOpenAI(payload.tool_choice),
     thinking_budget: thinkingBudget,
     ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+    ...(promptCacheKey ? { prompt_cache_key: promptCacheKey } : {}),
   }
 }
 

--- a/src/routes/messages/responses-translation.ts
+++ b/src/routes/messages/responses-translation.ts
@@ -1021,7 +1021,7 @@ const createCompactionThinkingBlock = (
 
   return {
     type: "thinking",
-    thinking: THINKING_TEXT,
+    thinking: "",
     signature: encodeCompactionCarrierSignature({
       id: item.id,
       encrypted_content: item.encrypted_content,

--- a/src/routes/messages/stream-translation.ts
+++ b/src/routes/messages/stream-translation.ts
@@ -9,7 +9,6 @@ import {
   type AnthropicStreamEventData,
   type AnthropicStreamState,
 } from "~/lib/types/anthropic"
-import { THINKING_TEXT } from "./non-stream-translation"
 import { mapOpenAIStopReasonToAnthropic } from "./utils"
 
 function isToolBlockOpen(state: AnthropicStreamState): boolean {
@@ -396,7 +395,7 @@ function handleReasoningOpaque(
         index: state.contentBlockIndex,
         delta: {
           type: "thinking_delta",
-          thinking: THINKING_TEXT, // Compatible with opencode, it will filter out blocks where the thinking text is empty, so we add a default thinking text here
+          thinking: "",
         },
       },
       {

--- a/src/routes/responses/messages-translation.ts
+++ b/src/routes/responses/messages-translation.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto"
 
 import { compactTextOnlyGuard } from "~/lib/compact"
+import { requestContext } from "~/lib/request-context"
 import type {
   AnthropicAssistantContentBlock,
   AnthropicAssistantMessage,
@@ -135,6 +136,7 @@ export function translateResponsesToMessages(
   applyEphemeralCacheControl(messages, system)
 
   const reasoningEffort = translateReasoningEffort(payload.reasoning?.effort)
+  const metadataUserId = resolveMetadataUserId(payload)
   const messagesPayload: AnthropicMessagesPayload = {
     model: options.model,
     messages,
@@ -155,9 +157,7 @@ export function translateResponsesToMessages(
     ) ?
       { service_tier: payload.service_tier }
     : {}),
-    ...(resolveMetadataUserId(payload) ?
-      { metadata: { user_id: resolveMetadataUserId(payload) } }
-    : {}),
+    ...(metadataUserId ? { metadata: { user_id: metadataUserId } } : {}),
   }
 
   return {
@@ -1009,6 +1009,8 @@ function translateReasoningEffort(
 }
 
 function resolveMetadataUserId(payload: ResponsesPayload): string | undefined {
+  const sessionAffinity = requestContext.getStore()?.sessionAffinity?.trim()
+  if (sessionAffinity) return sessionAffinity
   const metadataUserId = payload.metadata?.user_id
   if (metadataUserId?.trim()) return metadataUserId
   if (payload.safety_identifier?.trim()) return payload.safety_identifier

--- a/tests/anthropic-request.test.ts
+++ b/tests/anthropic-request.test.ts
@@ -5,6 +5,7 @@ import type { AnthropicMessagesPayload } from "~/lib/types/anthropic"
 import type { Model } from "~/lib/types/models"
 
 import { COMPACT_REQUEST } from "~/lib/compact"
+import { requestContext } from "~/lib/request-context"
 import { state } from "~/lib/state"
 import {
   RICH_TOOL_RESULT_MOVED_TEXT,
@@ -109,6 +110,48 @@ function createThinkingModel(): Model {
 }
 
 describe("Anthropic to OpenAI translation logic", () => {
+  test("maps request session affinity to prompt_cache_key", () => {
+    const anthropicPayload: AnthropicMessagesPayload = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello!" }],
+      max_tokens: 0,
+    }
+
+    const openAIPayload = requestContext.run(
+      {
+        parentSessionId: undefined,
+        sessionAffinity: " opencode-session ",
+        startTime: Date.now(),
+        traceId: "trace-123",
+        userAgent: "test",
+      },
+      () => translateToOpenAI(anthropicPayload),
+    )
+
+    expect(openAIPayload.prompt_cache_key).toBe("opencode-session")
+  })
+
+  test("omits prompt_cache_key when request session affinity is blank", () => {
+    const anthropicPayload: AnthropicMessagesPayload = {
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Hello!" }],
+      max_tokens: 0,
+    }
+
+    const openAIPayload = requestContext.run(
+      {
+        parentSessionId: undefined,
+        sessionAffinity: "   ",
+        startTime: Date.now(),
+        traceId: "trace-123",
+        userAgent: "test",
+      },
+      () => translateToOpenAI(anthropicPayload),
+    )
+
+    expect(openAIPayload).not.toHaveProperty("prompt_cache_key")
+  })
+
   test("should translate minimal Anthropic payload to valid OpenAI payload", () => {
     const anthropicPayload: AnthropicMessagesPayload = {
       model: "gpt-4o",

--- a/tests/responses-messages-translation.test.ts
+++ b/tests/responses-messages-translation.test.ts
@@ -5,6 +5,7 @@ import type {
   ResponsesPayload,
   ResponseStreamEvent,
 } from "~/lib/types/responses"
+import { requestContext } from "~/lib/request-context"
 import {
   decodeMessagesCompaction,
   encodeMessagesCompaction,
@@ -31,6 +32,68 @@ const expectCanonicalBase64 = (value: string | undefined) => {
 }
 
 describe("Responses Lite to Messages translation", () => {
+  test("prefers request session affinity for metadata user id", () => {
+    const result = requestContext.run(
+      {
+        parentSessionId: undefined,
+        sessionAffinity: " request-session ",
+        startTime: Date.now(),
+        traceId: "trace-123",
+        userAgent: "test",
+      },
+      () =>
+        translate({
+          input: "Hello",
+          metadata: { user_id: "metadata-user" },
+          prompt_cache_key: "prompt-cache-user",
+          safety_identifier: "safety-user",
+        }),
+    )
+
+    expect(result.messagesPayload.metadata).toEqual({
+      user_id: "request-session",
+    })
+  })
+
+  test("ignores blank session affinity and preserves payload fallbacks", () => {
+    const results = requestContext.run(
+      {
+        parentSessionId: undefined,
+        sessionAffinity: "   ",
+        startTime: Date.now(),
+        traceId: "trace-123",
+        userAgent: "test",
+      },
+      () => [
+        translate({
+          input: "Hello",
+          metadata: { user_id: "metadata-user" },
+          prompt_cache_key: "prompt-cache-user",
+          safety_identifier: "safety-user",
+        }),
+        translate({
+          input: "Hello",
+          metadata: { user_id: "   " },
+          prompt_cache_key: "prompt-cache-user",
+          safety_identifier: "safety-user",
+        }),
+        translate({
+          input: "Hello",
+          prompt_cache_key: "prompt-cache-user",
+          safety_identifier: "   ",
+        }),
+        translate({ input: "Hello" }),
+      ],
+    )
+
+    expect(results.map((result) => result.messagesPayload.metadata)).toEqual([
+      { user_id: "metadata-user" },
+      { user_id: "safety-user" },
+      { user_id: "prompt-cache-user" },
+      undefined,
+    ])
+  })
+
   test("groups the first five developer prompts into two system blocks", () => {
     const result = translate({
       instructions: "Base instructions",


### PR DESCRIPTION
## 上游变更（caozhiyuan/dev d808aa2..09aadac）

- **5ec7c12** feat: ChatCompletionsPayload 新增 prompt_cache_key；messages→chat 翻译从 requestContext.sessionAffinity 注入；Responses→messages 桥 sessionAffinity 优先于 payload metadata
- **07be78a** feat: prompt cache key 来源扩展为 metadata.user_id sessionId 优先（复用 parseUserIdMetadata）、sessionAffinity 兜底
- **09aadac** feat: signature-only thinking 块输出空 thinking 文本替代 "Thinking..." 占位（stream/non-stream/responses 三路），入站仍剥旧占位
- 958054c / 2142453：版本 bump 2.1.7 / 2.1.8

## 冲突预测

本地 merge-tree 预测 1 个冲突文件：src/routes/messages/non-stream-translation.ts（我方 09aadac 同方向的空 thinking 改动与上游实现相碰）。以 GitHub mergeable 为准。

按 best-of-both-worlds 流程：冲突逐块分析后等拍板，不在 czy-all 上解。